### PR TITLE
Feature/config in context

### DIFF
--- a/test/shared/BlackScholes.ts
+++ b/test/shared/BlackScholes.ts
@@ -1,5 +1,6 @@
 /// SDK Imports
 import { std_n_cdf } from './CumulativeNormalDistribution'
+import { getProportionalVol } from './ReplicationMath'
 
 /**
  * @param strike Strike price of option
@@ -30,4 +31,13 @@ export function callDelta(strike: number, sigma: number, tau: number, spot: numb
   const d1 = calculateD1(strike, sigma, tau, spot)
   const delta: number = std_n_cdf(d1)
   return delta
+}
+
+/**
+ * @returns Black-Scholes price of call option with parameters
+ */
+export function premium(strike: number, sigma: number, tau: number, spot: number): number {
+  const d1 = calculateD1(strike, sigma, tau, spot)
+  const d2 = d1 - getProportionalVol(sigma, tau)
+  return std_n_cdf(d1) * spot - std_n_cdf(d2) * strike * Math.exp(-tau * 0)
 }

--- a/test/unit/config.ts
+++ b/test/unit/config.ts
@@ -1,0 +1,58 @@
+import { parseWei, Percentage, Time, Wei, toBN } from 'web3-units'
+import { callDelta, premium } from '../shared'
+
+/**
+ * @notice Calibration Struct; Class representation of each Curve's parameters
+ * @dev    Call options only.
+ */
+export class Config {
+  public readonly strike: Wei
+  public readonly sigma: Percentage
+  public readonly maturity: Time
+  public readonly lastTimestamp: Time
+  public readonly spot: Wei
+
+  /**
+   *
+   * @param strike Strike price as a float
+   * @param sigma Volatility percentage as a float, e.g. 1 = 100%
+   * @param maturity Timestamp in seconds
+   * @param lastTimestamp Timestamp in seconds
+   * @param spot Value of risky asset in units of riskless asset
+   */
+  constructor(strike: number, sigma: number, maturity: number, lastTimestamp: number, spot: number) {
+    this.strike = parseWei(strike)
+    this.sigma = new Percentage(toBN(sigma * Percentage.Mantissa))
+    this.maturity = new Time(maturity) // in seconds, because `block.timestamp` is in seconds
+    this.lastTimestamp = new Time(lastTimestamp) // in seconds, because `block.timestamp` is in seconds
+    this.spot = parseWei(spot)
+  }
+
+  /**
+   * @returns Time until expiry
+   */
+  get tau(): Time {
+    return this.maturity.sub(this.lastTimestamp)
+  }
+
+  /**
+   * @returns Change in option premium wrt change in underlying spot price
+   */
+  get delta(): number {
+    return callDelta(this.strike.float, this.sigma.float, this.tau.years, this.spot.float)
+  }
+
+  /**
+   * @returns Black-Scholes implied premium
+   */
+  get premium(): number {
+    return premium(this.strike.float, this.sigma.float, this.tau.years, this.spot.float)
+  }
+
+  /**
+   * @returns Spot price is above strike price
+   */
+  get inTheMoney(): boolean {
+    return this.strike.float >= this.spot.float
+  }
+}

--- a/test/unit/createTestConfigs.ts
+++ b/test/unit/createTestConfigs.ts
@@ -1,0 +1,93 @@
+import { Config } from './config'
+import { parseWei, Percentage, toBN, Time, Wei } from 'web3-units'
+import { Configs } from '../../types'
+
+function parsePercentage(percent: number): Percentage {
+  return new Percentage(toBN(percent * Percentage.Mantissa))
+}
+
+function parseTime(years: number): Time {
+  return new Time(years * Time.YearInSeconds)
+}
+
+export const DEFAULT_CONFIG: Config = new Config(25, 1, Time.YearInSeconds, 0, 10)
+
+export default function createTestConfigs(
+  strikes: number[],
+  sigmas: number[],
+  maturities: number[],
+  spots: number[]
+): Configs {
+  const cStrikes = curvesWithStrikes(strikes)
+  const cSigmas = curvesWithSigmas(sigmas)
+  const cMaturities = curvesWithMaturities(maturities)
+  const cSpots = curvesWithSpotPrices(spots)
+
+  return {
+    all: [...cStrikes, ...cSigmas, ...cMaturities, ...cSpots],
+    strikes: cStrikes,
+    sigmas: cSigmas,
+    maturities: cMaturities,
+    spots: cSpots,
+  }
+}
+
+export function curvesWithStrikes(strikes: number[]): Config[] {
+  return strikes
+    .map(parseWei)
+    .map(
+      (strike) =>
+        new Config(
+          strike.float,
+          DEFAULT_CONFIG.sigma.float,
+          DEFAULT_CONFIG.maturity.raw,
+          DEFAULT_CONFIG.lastTimestamp.raw,
+          DEFAULT_CONFIG.spot.float
+        )
+    )
+}
+
+export function curvesWithSigmas(sigmas: number[]): Config[] {
+  return sigmas
+    .map(parsePercentage)
+    .map(
+      (sigma) =>
+        new Config(
+          DEFAULT_CONFIG.strike.float,
+          sigma.float,
+          DEFAULT_CONFIG.maturity.raw,
+          DEFAULT_CONFIG.lastTimestamp.raw,
+          DEFAULT_CONFIG.spot.float
+        )
+    )
+}
+
+export function curvesWithMaturities(maturities: number[]): Config[] {
+  return maturities
+    .map(parseTime)
+    .map(
+      (maturity) =>
+        new Config(
+          DEFAULT_CONFIG.strike.float,
+          DEFAULT_CONFIG.sigma.float,
+          maturity.raw,
+          DEFAULT_CONFIG.lastTimestamp.raw,
+          DEFAULT_CONFIG.spot.float
+        )
+    )
+}
+
+export function curvesWithSpotPrices(spots: number[]): Config[] {
+  return spots
+    .map(parseWei)
+    .map(
+      (spot) =>
+        new Config(
+          DEFAULT_CONFIG.strike.float,
+          DEFAULT_CONFIG.sigma.float,
+          DEFAULT_CONFIG.maturity.raw,
+          DEFAULT_CONFIG.lastTimestamp.raw,
+          spot.float
+        )
+    )
+}

--- a/test/unit/libraries/blackScholes.ts
+++ b/test/unit/libraries/blackScholes.ts
@@ -2,7 +2,7 @@ import { waffle } from 'hardhat'
 import { expect } from 'chai'
 import { TestBlackScholes } from '../../../typechain'
 import { Integer64x64, Wei } from 'web3-units'
-import loadContext, { config } from '../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../context'
 import { callDelta, calculateD1, moneyness } from '../../shared/BlackScholes'
 
 const { strike, sigma, maturity, lastTimestamp, spot } = config

--- a/test/unit/libraries/replicationMath.ts
+++ b/test/unit/libraries/replicationMath.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { TestReplicationMath } from '../../../typechain'
 import { Integer64x64, parseWei, Time } from 'web3-units'
 import { getProportionalVol, getTradingFunction, getInverseTradingFunction, calcInvariant } from '../../shared'
-import loadContext, { config } from '../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../context'
 
 const { strike, sigma, maturity, lastTimestamp } = config
 

--- a/test/unit/primitiveEngine/effect/allocate.ts
+++ b/test/unit/primitiveEngine/effect/allocate.ts
@@ -5,7 +5,7 @@ import { parseWei } from 'web3-units'
 
 import { allocateFragment } from '../fragments'
 
-import loadContext, { config } from '../../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 
 const { strike, sigma, maturity, spot } = config
 const empty: BytesLike = constants.HashZero

--- a/test/unit/primitiveEngine/effect/borrow.ts
+++ b/test/unit/primitiveEngine/effect/borrow.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { constants, BytesLike, Wallet } from 'ethers'
 import { parseWei } from 'web3-units'
 
-import loadContext, { config } from '../../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 import { borrowFragment } from '../fragments'
 import { EngineBorrow, PrimitiveEngine } from '../../../../typechain'
 

--- a/test/unit/primitiveEngine/effect/create.ts
+++ b/test/unit/primitiveEngine/effect/create.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { BigNumber, constants, BytesLike } from 'ethers'
 import { parseWei, Wei } from 'web3-units'
 
-import loadContext, { config } from '../../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 import { createFragment } from '../fragments'
 
 const { strike, sigma, maturity, lastTimestamp, spot } = config

--- a/test/unit/primitiveEngine/effect/lend.ts
+++ b/test/unit/primitiveEngine/effect/lend.ts
@@ -6,7 +6,7 @@ import { parseWei } from 'web3-units'
 
 import { lendFragment } from '../fragments'
 
-import loadContext, { config } from '../../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 
 const { strike, sigma, maturity, spot } = config
 

--- a/test/unit/primitiveEngine/effect/reentrancy.ts
+++ b/test/unit/primitiveEngine/effect/reentrancy.ts
@@ -4,7 +4,7 @@ import { constants, BytesLike } from 'ethers'
 
 import { allocateFragment } from '../fragments'
 
-import loadContext, { config } from '../../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 
 const { strike, sigma, maturity, spot } = config
 const empty: BytesLike = constants.HashZero

--- a/test/unit/primitiveEngine/effect/remove.ts
+++ b/test/unit/primitiveEngine/effect/remove.ts
@@ -6,7 +6,7 @@ import { parseWei } from 'web3-units'
 
 import { removeFragment } from '../fragments'
 
-import loadContext, { config } from '../../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 const { strike, sigma, maturity, spot } = config
 
 const delLiquidity = parseWei('1')

--- a/test/unit/primitiveEngine/effect/repay.ts
+++ b/test/unit/primitiveEngine/effect/repay.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { BytesLike, constants } from 'ethers'
 import { parseWei, Percentage } from 'web3-units'
 
-import loadContext, { config } from '../../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 import { repayFragment } from '../fragments'
 
 let poolId: BytesLike

--- a/test/unit/primitiveEngine/effect/swap.ts
+++ b/test/unit/primitiveEngine/effect/swap.ts
@@ -4,7 +4,7 @@ import { ethers, waffle } from 'hardhat'
 import { BigNumber, BytesLike, constants, ContractTransaction, Wallet } from 'ethers'
 import { MockEngine, EngineAllocate, EngineSwap } from '../../../../typechain'
 // Context Imports
-import loadContext, { config } from '../../context'
+import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 import { swapFragment } from '../fragments'
 import { Wei, Percentage, Time, parseWei, Integer64x64, toBN } from 'web3-units'
 import { EngineEvents, ERC20Events, getSpotPrice } from '../../../shared'

--- a/test/unit/primitiveEngine/fragments.ts
+++ b/test/unit/primitiveEngine/fragments.ts
@@ -2,7 +2,7 @@ import { Wallet, constants } from 'ethers'
 import { Contracts } from '../../../types'
 import { parseWei } from 'web3-units'
 
-import { config } from '../context'
+import { DEFAULT_CONFIG as config } from '../context'
 
 const { strike, sigma, maturity, spot } = config
 const empty = constants.HashZero

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers'
 import { MockContract } from 'ethereum-waffle'
 import * as ContractTypes from '../typechain'
 import { DepositFunction, SwapFunction } from '../test/unit/createEngineFunctions'
-import { Wei, Time, Percentage } from 'web3-units'
+import { Config } from '../test/unit/config'
 
 export interface Functions {
   depositFunction: DepositFunction
@@ -42,12 +42,12 @@ export interface Mocks {
   factory: MockContract
 }
 
-export interface Config {
-  strike: Wei
-  sigma: Percentage
-  maturity: Time
-  lastTimestamp: Time
-  spot: Wei
+export interface Configs {
+  all: Config[]
+  strikes: Config[]
+  sigmas: Config[]
+  maturities: Config[]
+  spots: Config[]
 }
 
 declare module 'mocha' {
@@ -56,7 +56,7 @@ declare module 'mocha' {
     contracts: Contracts
     functions: Functions
     mocks: Mocks
-    config: Config
+    configs: Configs
   }
 }
 


### PR DESCRIPTION
Changelog:
- Adds config.ts folder to test/unit/, which has the class `Config`, very similar to our config object but with some getters to get common functions we need like getting the delta of the parameters
- Adds `createTestConfigs`, which has functions that return an array of `Config` classes based on changing 1 parameters and keeping all else the default.
- Modifies `context.ts` with a new attribute: `configs`, that is set to the return object of `createTestConfigs()`.

This setup allows us to specify an array of parameters, and injects the different configs into the mocha testing context.

To do:
- Implement using the context configs into test suite, and run the tests for each config (need to improve testing speed before we really commit to do this)