### PR TITLE
refactor(create): removes logic from create that requires payment

### DIFF
--- a/contracts/PrimitiveEngine.sol
+++ b/contracts/PrimitiveEngine.sol
@@ -103,9 +103,7 @@ contract PrimitiveEngine is IPrimitiveEngine {
         uint256 strike,
         uint64 sigma,
         uint32 maturity,
-        uint256 riskyPrice,
-        uint256 delLiquidity,
-        bytes calldata data
+        uint256 delta
     )
         external
         override
@@ -116,42 +114,25 @@ contract PrimitiveEngine is IPrimitiveEngine {
             uint256 delStable
         )
     {
-        if ((maturity * sigma * strike * delLiquidity) == 0) revert CalibrationError();
         poolId = keccak256(abi.encodePacked(factory, maturity, sigma, strike));
         if (settings[poolId].lastTimestamp != 0) revert PoolDuplicateError();
-
         uint32 timestamp = _blockTimestamp();
-
-        {
-            (uint256 strikePrice, uint256 vol) = (strike, sigma);
-            uint32 tau = maturity - timestamp;
-            int128 callDelta = BlackScholes.deltaCall(riskyPrice, strikePrice, vol, tau);
-            uint256 resRisky = uint256(1).fromUInt().sub(callDelta).parseUnits(); // risky = 1 - delta
-            uint256 resStable = ReplicationMath
-            .getTradingFunction(0, resRisky, 1e18, strikePrice, vol, tau)
-            .parseUnits();
-            delRisky = (resRisky * delLiquidity) / 1e18;
-            delStable = (resStable * delLiquidity) / 1e18;
-        }
-        {
-            uint256 balRisky = balanceRisky();
-            uint256 balStable = balanceStable();
-            IPrimitiveCreateCallback(msg.sender).createCallback(delRisky, delStable, data);
-            if (balanceRisky() < delRisky + balRisky) revert RiskyBalanceError(delRisky + balRisky, balanceRisky());
-            if (balanceStable() < delStable + balStable)
-                revert StableBalanceError(delStable + balStable, balanceStable());
-        }
-
-        Reserve.Data storage reserve = reserves[poolId];
-        reserve.allocate(delRisky, delStable, delLiquidity, timestamp);
-        positions.fetch(msg.sender, poolId).allocate(delLiquidity - 1000); // give liquidity to `msg.sender`, burn 1000 wei
-        settings[poolId] = Calibration({
+        Calibration memory cal = Calibration({
             strike: strike.toUint128(),
             sigma: sigma,
             maturity: maturity,
             lastTimestamp: timestamp
         });
-        emit Created(msg.sender, strike, sigma, maturity);
+
+        uint32 tau = cal.maturity - timestamp; // time until expiry
+        delRisky = 1e18 - delta; // risky = 1 - delta
+        delStable = ReplicationMath.getTradingFunction(0, delRisky, 1e18, cal.strike, cal.sigma, tau).parseUnits();
+        if ((delRisky * delStable) == 0) revert CalibrationError();
+
+        settings[poolId] = cal; // initialize calibration
+        Reserve.Data storage reserve = reserves[poolId];
+        reserve.allocate(delRisky, delStable, 1e18, timestamp); // initialize reserves
+        emit Created(msg.sender, cal.strike, cal.sigma, cal.maturity);
     }
 
     // ===== Margin =====
@@ -203,7 +184,7 @@ contract PrimitiveEngine is IPrimitiveEngine {
             reserve.reserveStable
         );
 
-        if (resLiquidity == 0) revert UninitializedError();
+        if (reserve.blockTimestamp == 0) revert UninitializedError();
         delRisky = (resRisky * delLiquidity) / resLiquidity; // amount of risky tokens to provide
         delStable = (resStable * delLiquidity) / resLiquidity; // amount of stable tokens to provide
         if (delRisky * delStable == 0) revert ZeroDeltasError();

--- a/contracts/interfaces/engine/IPrimitiveEngineActions.sol
+++ b/contracts/interfaces/engine/IPrimitiveEngineActions.sol
@@ -11,9 +11,7 @@ interface IPrimitiveEngineActions {
     /// @param  strike  Strike price of the option to calibrate to
     /// @param  sigma   Volatility of the option to calibrate to
     /// @param  maturity    Maturity timestamp of the option
-    /// @param  riskyPrice  Amount of stable tokens required to purchase 1 unit of the risky token, spot price
-    /// @param  delLiquidity Amount of liquidity to initialize the pool with
-    /// @param  data    Arbitrary data that is passed to the createCallback function
+    /// @param  delta   Call option delta, greek to represent the change in option value wrt to a 1% change in underlying value
     /// @return poolId  Keccak256 hash of the parameters strike, sigma, and maturity, use to identify this option
     /// delRisky        Amount of risky tokens provided to reserves
     /// delStable       Amount of stable tokens provided to reserves
@@ -21,9 +19,7 @@ interface IPrimitiveEngineActions {
         uint256 strike,
         uint64 sigma,
         uint32 maturity,
-        uint256 riskyPrice,
-        uint256 delLiquidity,
-        bytes calldata data
+        uint256 delta
     )
         external
         returns (

--- a/contracts/test/engine/EngineCreate.sol
+++ b/contracts/test/engine/EngineCreate.sol
@@ -30,22 +30,10 @@ contract EngineCreate {
         uint256 strike,
         uint256 sigma,
         uint256 maturity,
-        uint256 riskyPrice,
-        uint256 delLiquidity,
-        bytes calldata data
+        uint256 delta
     ) public {
         CALLER = msg.sender;
-        IPrimitiveEngine(engine).create(strike, uint64(sigma), uint32(maturity), riskyPrice, delLiquidity, data);
-    }
-
-    function createCallback(
-        uint256 delRisky,
-        uint256 delStable,
-        bytes calldata data
-    ) public {
-        data;
-        IERC20(risky).transferFrom(CALLER, engine, delRisky);
-        IERC20(stable).transferFrom(CALLER, engine, delStable);
+        IPrimitiveEngine(engine).create(strike, uint64(sigma), uint32(maturity), delta);
     }
 
     function fetch(bytes32 pid)

--- a/contracts/test/engine/MockEngine.sol
+++ b/contracts/test/engine/MockEngine.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.6;
 import "../../PrimitiveEngine.sol";
 
 contract MockEngine is PrimitiveEngine {
-    uint256 public time = 0;
+    uint256 public time = 1;
 
     function advanceTime(uint256 by) external {
         time += by;

--- a/contracts/test/engine/ReentrancyAttacker.sol
+++ b/contracts/test/engine/ReentrancyAttacker.sol
@@ -13,7 +13,7 @@ contract ReentrancyAttacker {
     uint256 private _strike;
     uint256 private _sigma;
     uint256 private _maturity;
-    uint256 private _riskyPrice;
+    uint256 private _delta;
     uint256 private _delLiquidity;
     bytes32 private _poolId;
     address private _owner;
@@ -34,29 +34,16 @@ contract ReentrancyAttacker {
         uint256 strike,
         uint256 sigma,
         uint256 maturity,
-        uint256 riskyPrice,
-        uint256 delLiquidity,
-        bytes calldata data
+        uint256 delta
     ) public {
         CALLER = msg.sender;
 
         _strike = strike;
         _sigma = sigma;
         _maturity = maturity;
-        _riskyPrice = riskyPrice;
-        _delLiquidity = delLiquidity;
+        _delta = delta;
 
-        IPrimitiveEngine(engine).create(strike, uint64(sigma), uint32(maturity), riskyPrice, delLiquidity, data);
-    }
-
-    function createCallback(
-        uint256 delRisky,
-        uint256 delStable,
-        bytes calldata data
-    ) public {
-        delRisky;
-        delStable;
-        IPrimitiveEngine(engine).create(_strike, uint64(_sigma), uint32(_maturity), _riskyPrice, _delLiquidity, data);
+        IPrimitiveEngine(engine).create(strike, uint64(sigma), uint32(maturity), delta);
     }
 
     function deposit(

--- a/test/unit/createTestConfigs.ts
+++ b/test/unit/createTestConfigs.ts
@@ -10,7 +10,7 @@ function parseTime(years: number): Time {
   return new Time(years * Time.YearInSeconds)
 }
 
-export const DEFAULT_CONFIG: Config = new Config(25, 1, Time.YearInSeconds, 0, 10)
+export const DEFAULT_CONFIG: Config = new Config(25, 1, Time.YearInSeconds, 1, 10)
 
 export default function createTestConfigs(
   strikes: number[],

--- a/test/unit/primitiveEngine/effect/allocate.ts
+++ b/test/unit/primitiveEngine/effect/allocate.ts
@@ -74,12 +74,7 @@ describe('allocate', function () {
 
       it('reverts if there is no liquidity', async function () {
         await expect(
-          this.contracts.engineAllocate.allocateFromMargin(
-            '0x41b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d',
-            this.signers[0].address,
-            parseWei('1').raw,
-            empty
-          )
+          this.contracts.engineAllocate.allocateFromMargin(empty, this.signers[0].address, parseWei('1').raw, empty)
         ).to.be.revertedWith('UninitializedError()')
       })
 

--- a/test/unit/primitiveEngine/effect/reentrancy.ts
+++ b/test/unit/primitiveEngine/effect/reentrancy.ts
@@ -7,7 +7,7 @@ import { reentrancyFragment } from '../fragments'
 import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 import { computePoolId } from '../../../shared/utils'
 
-const { strike, sigma, maturity, spot } = config
+const { strike, sigma, maturity, spot, delta } = config
 const empty: BytesLike = constants.HashZero
 let poolId: string
 
@@ -24,17 +24,9 @@ describe('reentrancy', function () {
     poolId = computePoolId(this.contracts.factory.address, maturity.raw, sigma.raw, strike.raw)
   })
 
-  describe('when calling create in the create callback', function () {
-    it('reverts the transaction', async function () {
-      await expect(
-        this.contracts.reentrancyAttacker.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
-      ).to.be.revertedWith('Locked')
-    })
-  })
-
   describe('when calling deposit in the deposit callback', function () {
     beforeEach(async function () {
-      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
     })
 
     it('reverts the transaction', async function () {
@@ -46,7 +38,7 @@ describe('reentrancy', function () {
 
   describe('when calling allocate in the allocate callback', function () {
     beforeEach(async function () {
-      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
     })
 
     it('reverts the transaction', async function () {
@@ -58,7 +50,7 @@ describe('reentrancy', function () {
 
   describe('when calling remove in the remove callback', function () {
     beforeEach(async function () {
-      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
       await this.contracts.engineAllocate.allocateFromExternal(
         poolId,
         this.contracts.reentrancyAttacker.address,
@@ -74,7 +66,7 @@ describe('reentrancy', function () {
 
   describe('when calling borrow in the borrow callback', function () {
     beforeEach(async function () {
-      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
       await this.contracts.engineAllocate.allocateFromExternal(
         poolId,
         this.contracts.engineLend.address,
@@ -93,7 +85,7 @@ describe('reentrancy', function () {
 
   describe('when calling repay in the repay callback', function () {
     beforeEach(async function () {
-      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+      await this.contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
       await this.contracts.engineAllocate.allocateFromExternal(
         poolId,
         this.contracts.engineLend.address,

--- a/test/unit/primitiveEngine/fragments.ts
+++ b/test/unit/primitiveEngine/fragments.ts
@@ -5,7 +5,7 @@ import { parseWei } from 'web3-units'
 import { DEFAULT_CONFIG as config } from '../context'
 import { computePoolId } from '../../shared/utils'
 
-const { strike, sigma, maturity, spot } = config
+const { strike, sigma, maturity, spot, delta } = config
 const empty = constants.HashZero
 
 export async function createFragment(signers: Wallet[], contracts: Contracts): Promise<void> {
@@ -45,7 +45,9 @@ export async function allocateFragment(signers: Wallet[], contracts: Contracts):
   await contracts.stable.approve(contracts.engineCreate.address, constants.MaxUint256)
   await contracts.risky.approve(contracts.engineCreate.address, constants.MaxUint256)
 
-  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
+  const poolId = computePoolId(contracts.factory.address, maturity.raw, sigma.raw, strike.raw)
+  await contracts.engineAllocate.allocateFromExternal(poolId, signers[0].address, parseWei('100').raw, empty)
 }
 
 export async function removeFragment(signers: Wallet[], contracts: Contracts): Promise<void> {
@@ -59,7 +61,7 @@ export async function removeFragment(signers: Wallet[], contracts: Contracts): P
   await contracts.stable.approve(contracts.engineCreate.address, constants.MaxUint256)
   await contracts.risky.approve(contracts.engineCreate.address, constants.MaxUint256)
 
-  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
 
   const poolId = computePoolId(contracts.factory.address, maturity.raw, sigma.raw, strike.raw)
 
@@ -77,7 +79,7 @@ export async function lendFragment(signers: Wallet[], contracts: Contracts): Pro
   await contracts.stable.approve(contracts.engineCreate.address, constants.MaxUint256)
   await contracts.risky.approve(contracts.engineCreate.address, constants.MaxUint256)
 
-  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
 
   const poolId = computePoolId(contracts.factory.address, maturity.raw, sigma.raw, strike.raw)
 
@@ -97,7 +99,7 @@ export async function borrowFragment(signers: Wallet[], contracts: Contracts): P
   await contracts.stable.approve(contracts.engineBorrow.address, constants.MaxUint256)
   await contracts.risky.approve(contracts.engineBorrow.address, constants.MaxUint256)
 
-  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
 
   const poolId = computePoolId(contracts.factory.address, maturity.raw, sigma.raw, strike.raw)
 
@@ -119,7 +121,7 @@ export async function swapFragment(signers: Wallet[], contracts: Contracts): Pro
   await contracts.engineDeposit.deposit(contracts.engineAllocate.address, parseWei('1000').raw, parseWei('1000').raw, empty)
   await contracts.engineDeposit.deposit(contracts.engineSwap.address, parseWei('1000').raw, parseWei('1000').raw, empty)
   await contracts.engineDeposit.deposit(signers[0].address, parseWei('10000').raw, parseWei('10000').raw, empty)
-  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
   // const poolId = computePoolId(contracts.factory.address, maturity.raw, sigma.raw, strike.raw)
   // await contracts.engineAllocate.allocateFromExternal(poolId, contracts.engineAllocate.address, parseWei('1000').raw, empty)
 }
@@ -137,7 +139,7 @@ export async function repayFragment(signers: Wallet[], contracts: Contracts): Pr
   await contracts.stable.approve(contracts.engineRepay.address, constants.MaxUint256)
   await contracts.risky.approve(contracts.engineRepay.address, constants.MaxUint256)
 
-  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, spot.raw, parseWei('1').raw, empty)
+  await contracts.engineCreate.create(strike.raw, sigma.raw, maturity.raw, parseWei(delta).raw)
 
   const poolId = computePoolId(contracts.factory.address, maturity.raw, sigma.raw, strike.raw)
 


### PR DESCRIPTION
## Changelog:
- Refactors create function in core
- Removes `delLiquidity`, `riskyPrice,` and `data` arguments to create function
- Adds `delta` argument to create function
- Remove create function callback
- Liquidity is initialized at 1 unit of replication, with virtual balances. These virtual balances will serve as a starting point for linearly scaling amount of units we are replicating (total liquidity supply)

## Why I made these changes:
- argument changes: `riskyPrice` was used to calculate delta of the call option on-chain. However, its trivial to manipulate the calculated delta because any of the other option parameters can be passed in as arguments. Additionally, on-chain delta value is an approximation, which reduces the accuracy of the replication. The `data` argument was removed because of the create functionality/pay for initial liquidity was removed
- removing required initial liquidity into 1 unit of virtual balances: allocating initial liquidity in the create call duplicates the logic we have in `allocate`. It would be better to initialize state of the curve, and allocate using the appropriate logic. The problem is how the curve's initial balances are allocated, as they have to be calibrated to replicate correctly. Therefore, the initial balances _are set to 1 unit of replication, as a virtual balance_

## Note: some tests start to fail
- Fixed it so all `create` tests pass
- Reentrancy tests fail
- Some allocate tests fail
- Swap tests fail
