### PR TITLE
Feat/tau update fn

### DIFF
--- a/contracts/interfaces/engine/IPrimitiveEngineActions.sol
+++ b/contracts/interfaces/engine/IPrimitiveEngineActions.sol
@@ -5,6 +5,11 @@ pragma solidity 0.8.6;
 /// @author Primitive
 
 interface IPrimitiveEngineActions {
+    /// @notice             Updates the time until expiry of the option by setting its last timestamp value
+    /// @param  poolId      Keccak hash of the option parameters of a curve to interact with
+    /// @return lastTimestamp Timestamp loaded into the state of the pool's Calibration.lastTimestamp
+    function updateLastTimestamp(bytes32 poolId) external returns (uint32 lastTimestamp);
+
     /// @notice             Initializes a curve with parameters in the `settings` storage mapping in the Engine
     /// @param  strike      Strike price of the option to calibrate to
     /// @param  sigma       Volatility of the option to calibrate to


### PR DESCRIPTION
Moves tau update logic to an internal function. Adds an external function to expose the internal function. In swap, checks if the returned updated tau is less than the current block.timestamp + a 120s buffer, in that case, revert (since pool is expired).