### PR TITLE
Audit/pre draft changes - First Batch of Changes

### DIFF
--- a/contracts/PrimitiveEngine.sol
+++ b/contracts/PrimitiveEngine.sol
@@ -350,7 +350,8 @@ contract PrimitiveEngine is IPrimitiveEngine {
     /// @inheritdoc IPrimitiveEngineActions
     function borrow(
         bytes32 poolId,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bool fromMargin,
         bytes calldata data
     )
@@ -358,49 +359,68 @@ contract PrimitiveEngine is IPrimitiveEngine {
         override
         lock
         returns (
-            uint256 delRisky,
-            uint256 delStable,
-            uint256 premium
+            uint256 riskyDeficit,
+            uint256 riskySurplus,
+            uint256 stableDeficit,
+            uint256 stableSurplus
         )
     {
         // Source: Convex Payoff Approximation. https://stanford.edu/~guillean/papers/cfmm-lending.pdf. Section 5.
-        if (delLiquidity == 0) revert ZeroLiquidityError();
+        if (riskyCollateral == 0 && stableCollateral == 0) revert ZeroLiquidityError();
 
-        Reserve.Data storage reserve = reserves[poolId];
-        delRisky = (delLiquidity * reserve.reserveRisky) / reserve.liquidity; // amount of risky from removing
-        delStable = (delLiquidity * reserve.reserveStable) / reserve.liquidity; // amount of stable from removing
-        // 0. Update position of `msg.sender` by increasing `delLiquidity` units of debt
-        positions.borrow(poolId, delLiquidity);
-        // 1. Borrow `delLiquidity`: Reduce global reserve float, increase global debt
-        reserve.borrowFloat(delLiquidity);
-        // 2. Remove liquidity: Releases `risky` and `stable` tokens from curve
-        reserve.remove(delRisky, delStable, delLiquidity, _blockTimestamp());
-        // 3. Calculate amount of risky tokens needed to match amount of liquidity borrowed
-        premium = delLiquidity - delRisky; // premium that must be paid
-        // 4. Pay the premium
-        if (fromMargin) {
-            margins.withdraw(premium, 0); // pay premium from margin risky balance
-            margins[msg.sender].deposit(0, delStable); // deposit stable tokens from removed liquidity
-        } else {
-            (uint256 balRisky, uint256 balStable) = (balanceRisky(), balanceStable());
-            IERC20(stable).safeTransfer(msg.sender, delStable); // transfer stable tokens to use in callback
-            IPrimitiveBorrowCallback(msg.sender).borrowCallback(delLiquidity, delRisky, delStable, data); // agnostic
+        positions.borrow(poolId, riskyCollateral, stableCollateral);
 
-            if (balanceRisky() < balRisky + premium) revert RiskyBalanceError(balRisky + premium, balanceRisky());
-            if (balanceStable() < balStable - delStable)
-                revert StableBalanceError(balStable - delStable, balanceStable());
+        {
+            // liquidity scope
+            Reserve.Data storage reserve = reserves[poolId];
+            uint256 strike = uint256(calibrations[poolId].strike);
+            uint256 delLiquidity = riskyCollateral + (stableCollateral * 1e18) / strike; // total debt incurred
+            uint256 delRisky = (delLiquidity * reserve.reserveRisky) / reserve.liquidity; // risky tokens from remove
+            uint256 delStable = (delLiquidity * reserve.reserveStable) / reserve.liquidity; // stable tokens from remove
+
+            if (riskyCollateral > delRisky) riskyDeficit = riskyCollateral - delRisky;
+            else riskySurplus = delRisky - riskyCollateral;
+            if (stableCollateral > delStable) stableDeficit = stableCollateral - delStable;
+            else stableSurplus = delStable - stableCollateral;
+
+            reserve.borrowFloat(delLiquidity); // decrease: global float, increase: global debt
+            reserve.remove(delRisky, delStable, delLiquidity, _blockTimestamp()); // decrease: risky, stable, liquidity
         }
 
-        emit Borrowed(msg.sender, poolId, delLiquidity, premium);
+        if (fromMargin) {
+            margins.withdraw(riskyDeficit, stableDeficit); // receive deficits
+            margins[msg.sender].deposit(riskySurplus, stableSurplus); // send surpluses
+        } else {
+            if (riskySurplus > 0) IERC20(risky).safeTransfer(msg.sender, riskySurplus); // send surpluses
+            if (stableSurplus > 0) IERC20(stable).safeTransfer(msg.sender, stableSurplus); // send surpluses
+
+            (uint256 balRisky, uint256 balStable) = (balanceRisky(), balanceStable()); // notice line placement
+            IPrimitiveBorrowCallback(msg.sender).borrowCallback(riskyDeficit, stableDeficit, data); // request deficits
+
+            if (balanceRisky() < balRisky + riskyDeficit)
+                revert RiskyBalanceError(balRisky + riskyDeficit, balanceRisky());
+            if (balanceStable() < balStable + stableDeficit)
+                revert StableBalanceError(balStable + stableDeficit, balanceStable());
+        }
+
+        emit Borrowed(
+            msg.sender,
+            poolId,
+            riskyCollateral,
+            stableCollateral,
+            riskyDeficit,
+            riskySurplus,
+            stableDeficit,
+            stableSurplus
+        );
     }
 
     /// @inheritdoc IPrimitiveEngineActions
-    /// @dev    Reverts early if `delLiquidity` > debt, or debt is 0
-    ///         Important: If the pool is expired, any position can be repaid
     function repay(
         bytes32 poolId,
         address recipient,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bool fromMargin,
         bytes calldata data
     )
@@ -408,37 +428,64 @@ contract PrimitiveEngine is IPrimitiveEngine {
         override
         lock
         returns (
-            uint256 delRisky,
-            uint256 delStable,
-            uint256 premium
+            uint256 riskyDeficit,
+            uint256 riskySurplus,
+            uint256 stableDeficit,
+            uint256 stableSurplus
         )
     {
-        uint32 timestamp = _blockTimestamp();
-        bool expired = timestamp >= calibrations[poolId].maturity;
-        address account = expired ? recipient : msg.sender; // allows repayment of any position after expiry
-        positions.fetch(account, poolId).repay(delLiquidity); // decrease debt of Position
-
-        Reserve.Data storage reserve = reserves[poolId];
-        delRisky = (delLiquidity * reserve.reserveRisky) / reserve.liquidity; // amount of risky required to allocate
-        delStable = (delLiquidity * reserve.reserveStable) / reserve.liquidity; // amount of stable required to allocate
-        premium = delLiquidity - delRisky; // amount of excess risky, used to pay for stable side
-
-        if (fromMargin) {
-            margins.withdraw(0, delStable); // pay stables from margin balance
-            margins[account].deposit(premium, 0); // send remainder `premium` of risky to margin
-        } else {
-            (uint256 balRisky, uint256 balStable) = (balanceRisky(), balanceStable());
-            IERC20(risky).safeTransfer(msg.sender, premium); // proceeds transferred out optimistically
-            IPrimitiveRepayCallback(msg.sender).repayCallback(delStable, data); // agnostic payment of delStable
-
-            if (balanceRisky() < balRisky - premium) revert RiskyBalanceError(balRisky - premium, balanceRisky());
-            if (balanceStable() < balStable + delStable)
-                revert StableBalanceError(balStable + delStable, balanceStable());
+        Calibration memory cal = calibrations[poolId];
+        {
+            // position scope
+            bytes32 id = poolId;
+            bool expired = _blockTimestamp() >= cal.maturity + 86400;
+            address account = expired ? recipient : msg.sender;
+            positions.fetch(account, id).repay(riskyCollateral, stableCollateral); // increase: risky/stableCollateral
         }
 
-        reserve.allocate(delRisky, delStable, delLiquidity, timestamp); // increase: risky, stable, and liquidity
-        reserve.repayFloat(delLiquidity); // increase reserve float, decrease reserve debt
-        emit Repaid(msg.sender, recipient, poolId, delLiquidity, premium);
+        {
+            // liquidity scope
+            Reserve.Data storage reserve = reserves[poolId];
+            uint256 delLiquidity = riskyCollateral + (stableCollateral * 1e18) / uint256(cal.strike); // Debt sum
+            uint256 delRisky = (delLiquidity * reserve.reserveRisky) / reserve.liquidity; // risky tokens to allocate
+            uint256 delStable = (delLiquidity * reserve.reserveStable) / reserve.liquidity; // stable tokens allocate
+
+            if (delRisky > riskyCollateral) riskyDeficit = delRisky - riskyCollateral;
+            else riskySurplus = riskyCollateral - delRisky;
+            if (delStable > stableCollateral) stableDeficit = delStable - stableCollateral;
+            else stableSurplus = stableCollateral - delStable;
+
+            reserve.repayFloat(delLiquidity); // increase: float, decrease: debt
+            reserve.allocate(delRisky, delStable, delLiquidity, _blockTimestamp()); // increase: risky, stable, liquidity
+        }
+
+        if (fromMargin) {
+            margins.withdraw(riskyDeficit, stableDeficit); // receive deficits
+            margins[msg.sender].deposit(riskySurplus, stableSurplus); // send surpluses
+        } else {
+            if (riskySurplus > 0) IERC20(risky).safeTransfer(msg.sender, riskySurplus); // send surpluses
+            if (stableSurplus > 0) IERC20(stable).safeTransfer(msg.sender, stableSurplus); // send surpluses
+
+            (uint256 balRisky, uint256 balStable) = (balanceRisky(), balanceStable()); // notice line placement
+            IPrimitiveRepayCallback(msg.sender).repayCallback(riskyDeficit, stableDeficit, data); // request deficits
+
+            if (balanceRisky() < balRisky + riskyDeficit)
+                revert RiskyBalanceError(balRisky + riskyDeficit, balanceRisky());
+            if (balanceStable() < balStable + stableDeficit)
+                revert StableBalanceError(balStable + stableDeficit, balanceStable());
+        }
+
+        emit Repaid(
+            msg.sender,
+            recipient,
+            poolId,
+            riskyCollateral,
+            stableCollateral,
+            riskyDeficit,
+            riskySurplus,
+            stableDeficit,
+            stableSurplus
+        );
     }
 
     // ===== Swap and Liquidity Math =====

--- a/contracts/interfaces/callback/IPrimitiveBorrowCallback.sol
+++ b/contracts/interfaces/callback/IPrimitiveBorrowCallback.sol
@@ -5,15 +5,13 @@ pragma solidity 0.8.6;
 /// @author Primitive
 
 interface IPrimitiveBorrowCallback {
-    /// @notice Triggered when borrowing liquidity from an Engine
-    /// @param  delLiquidity Amonut of liquidity being borrowed
-    /// @param  delRisky     Amount of risky tokens required to initialize risky reserve
-    /// @param  delStable    Amount of stable tokens required to initialize stable reserve
-    /// @param  data         Calldata passed on borrow function call
+    /// @notice                 Triggered when borrowing liquidity from an Engine
+    /// @param  riskyDeficit    Amount of risky tokens requested to Engine
+    /// @param  stableDeficit   Amount of stable tokens requested to Engine
+    /// @param  data            Calldata passed on borrow function call
     function borrowCallback(
-        uint256 delLiquidity,
-        uint256 delRisky,
-        uint256 delStable,
+        uint256 riskyDeficit,
+        uint256 stableDeficit,
         bytes calldata data
     ) external;
 }

--- a/contracts/interfaces/callback/IPrimitiveRepayCallback.sol
+++ b/contracts/interfaces/callback/IPrimitiveRepayCallback.sol
@@ -5,8 +5,13 @@ pragma solidity 0.8.6;
 /// @author Primitive
 
 interface IPrimitiveRepayCallback {
-    /// @notice Triggered when repaying liquidity to an Engine
-    /// @param  delStable    Amount of stable tokens required to re-mint liquidity to pay back
-    /// @param  data         Calldata passed on repay function call
-    function repayCallback(uint256 delStable, bytes calldata data) external;
+    /// @notice                 Triggered when repaying liquidity to an Engine
+    /// @param  riskyDeficit    Amount of risky tokens requested to Engine
+    /// @param  stableDeficit   Amount of stable tokens requested to Engine
+    /// @param  data            Calldata passed on repay function call
+    function repayCallback(
+        uint256 riskyDeficit,
+        uint256 stableDeficit,
+        bytes calldata data
+    ) external;
 }

--- a/contracts/interfaces/engine/IPrimitiveEngineActions.sol
+++ b/contracts/interfaces/engine/IPrimitiveEngineActions.sol
@@ -114,46 +114,54 @@ interface IPrimitiveEngineActions {
     /// @notice             Borrows liquidity and removes it, adding a debt
     /// @dev                Increases the `msg.sender`'s position's liquidity value and adds the same to the debt
     /// @param  poolId      Keccak hash of the option parameters of a curve to interact with
-    /// @param  delLiquidity Amount of liquidity to borrow and add as debt
+    /// @param  riskyCollateral  Amount of risky collateral backing the liquidity debt, for risky / 1 = units of debt
+    /// @param  stableCollateral Amount of stable collateral backing the liquidity debt, for stable / K = units of debt
     /// @param  fromMargin  Use margin risky balance to pay premium?
     /// @param  data        Arbitrary data that is passed to the borrowCallback function
-    /// @return delRisky    Amount of risky tokens removed from liquidity borrowed
-    /// delStable           Amount of stable tokens removed from liquidity borrowed
-    /// premium             Price paid to open position
+    /// @return riskyDeficit    Amount of risky tokens requested to Engine
+    /// riskySurplus            Amount of risky tokens paid to user
+    /// stableDeficit           Amount of stable tokens requested to Engine
+    /// stableSurplus           Amount of stable tokens paid to user
     function borrow(
         bytes32 poolId,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bool fromMargin,
         bytes calldata data
     )
         external
         returns (
-            uint256 delRisky,
-            uint256 delStable,
-            uint256 premium
+            uint256 riskyDeficit,
+            uint256 riskySurplus,
+            uint256 stableDeficit,
+            uint256 stableSurplus
         );
 
     /// @notice             Pays back liquidity share debt by allocating liquidity
-    /// @dev                Reduces the `msg.sender`'s position's liquidity value and reduces the same to the debt value
+    /// @dev                Important: If the pool is expired, any position can be repaid to the position owner
     /// @param  poolId      Keccak hash of the option parameters of a curve to interact with
     /// @param  recipient   Position recipient to grant the borrowed liquidity shares
-    /// @param  delLiquidity Amount of liquidity to borrow and add as debt
+    /// @param  riskyCollateral    Amount of risky collateral to liquidate by repaying, for risky / 1 = units of debt
+    /// @param  stableCollateral   Amount of stable collateral to liquidate by repaying, for stable / K = units of debt
     /// @param  fromMargin  Whether the `msg.sender` uses their margin balance, or must send tokens
     /// @param  data        Arbitrary data that is passed to the repayCallback function
-    /// @return delRisky    Amount of risky tokens allocated as liquidity to pay debt
-    /// delStable           Amount of stable tokens allocated as liquidity to pay debt
-    /// premium             Price paid to the `recipient`'s margin account
+    /// @return riskyDeficit    Amount of risky tokens requested to Engine
+    /// riskySurplus            Amount of risky tokens paid to user
+    /// stableDeficit           Amount of stable tokens requested to Engine
+    /// stableSurplus           Amount of stable tokens paid to user
     function repay(
         bytes32 poolId,
         address recipient,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bool fromMargin,
         bytes calldata data
     )
         external
         returns (
-            uint256 delRisky,
-            uint256 delStable,
-            uint256 premium
+            uint256 riskyDeficit,
+            uint256 riskySurplus,
+            uint256 stableDeficit,
+            uint256 stableSurplus
         );
 }

--- a/contracts/interfaces/engine/IPrimitiveEngineEvents.sol
+++ b/contracts/interfaces/engine/IPrimitiveEngineEvents.sol
@@ -85,21 +85,42 @@ interface IPrimitiveEngineEvents {
     /// @notice             Adds liquidity shares to a `recipient`'s position while adding an equal amount of debt
     /// @param  recipient   Owner of the position which receives liquidity shares
     /// @param  poolId      Keccak hash of the option parameters of a curve to interact with
-    /// @param  delLiquidity Amount of liquidity shares borrowed, and added as debt
-    /// @param  premium     Amount of risky added from margin or external transfer
-    event Borrowed(address indexed recipient, bytes32 indexed poolId, uint256 delLiquidity, uint256 premium);
+    /// @param  riskyCollateral Amount of desired risky tokens backing liquidity debt
+    /// @param  stableCollateral Amount of desired stable tokens backing liquidity debt
+    /// @param  riskyDeficit    Amount of risky tokens requested to Engine
+    /// @param  riskySurplus    Amount of risky tokens paid to user
+    /// @param  stableDeficit   Amount of stable tokens requested to Engine
+    /// @param  stableSurplus   Amount of stable tokens paid to user
+    event Borrowed(
+        address indexed recipient,
+        bytes32 indexed poolId,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
+        uint256 riskyDeficit,
+        uint256 riskySurplus,
+        uint256 stableDeficit,
+        uint256 stableSurplus
+    );
 
     /// @notice             Repays a borrowed position, reduces liquidity shares of position and debt
     /// @param  from        Calling `msg.sender`
     /// @param  recipient   Owner of the position to repay
     /// @param  poolId      Keccak hash of the option parameters of a curve to interact with
-    /// @param  delLiquidity Amount of liquidity to pay
-    /// @param  premium     Amount of risky tokens returned to borrower
+    /// @param  riskyCollateral Amount of desired risky tokens backing liquidity debt
+    /// @param  stableCollateral Amount of desired stable tokens backing liquidity debt
+    /// @param  riskyDeficit    Amount of risky tokens requested to Engine
+    /// @param  riskySurplus    Amount of risky tokens paid to user
+    /// @param  stableDeficit   Amount of stable tokens requested to Engine
+    /// @param  stableSurplus   Amount of stable tokens paid to user
     event Repaid(
         address indexed from,
         address indexed recipient,
         bytes32 indexed poolId,
-        uint256 delLiquidity,
-        uint256 premium
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
+        uint256 riskyDeficit,
+        uint256 riskySurplus,
+        uint256 stableDeficit,
+        uint256 stableSurplus
     );
 }

--- a/contracts/interfaces/engine/IPrimitiveEngineView.sol
+++ b/contracts/interfaces/engine/IPrimitiveEngineView.sol
@@ -80,14 +80,16 @@ interface IPrimitiveEngineView {
     /// @param  posId       Keccak256 hash of owner address and poolId
     /// @return float       Liquidity that is supplied to be borrowed
     /// liquidity           Liquidity in the position
-    /// debt                Borrowed liquidity debt, must be repaid, also equal to risky balance of position
+    /// riskyCollateral     For every 1 risky collateral, 1 liquidity debt
+    /// stableCollateral    For every K stable collateral (K = strike), 1 liquidity debt
     function positions(bytes32 posId)
         external
         view
         returns (
             uint128 float,
             uint128 liquidity,
-            uint128 debt
+            uint128 riskyCollateral,
+            uint128 stableCollateral
         );
 
     /// @notice                 Fetchs the margin position of `account`

--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -13,7 +13,8 @@ library Position {
     struct Data {
         uint128 float; // Balance of supplied liquidity
         uint128 liquidity; // Balance of liquidity
-        uint128 debt; // Balance of liquidity debt that must be paid back, also balance of risky in position
+        uint128 riskyCollateral; // For every 1 risky collateral, 1 liquidity debt
+        uint128 stableCollateral; // For every K stable collateral (K is strike price), 1 liquidity debt
     }
 
     /// @notice             An Engine's mapping of position Ids to Position.Data structs can be used to fetch any Position
@@ -45,18 +46,6 @@ library Position {
         position.liquidity -= delLiquidity.toUint128();
     }
 
-    /// @notice             Increases debt balance of Position
-    /// @param poolId       Keccak256 hash of the engine address and pool parameters (strike, sigma, maturity)
-    /// @param delLiquidity Amount of liquidity to borrow
-    function borrow(
-        mapping(bytes32 => Data) storage positions,
-        bytes32 poolId,
-        uint256 delLiquidity
-    ) internal returns (Data storage position) {
-        position = fetch(positions, msg.sender, poolId);
-        position.debt += delLiquidity.toUint128(); // add the debt post position manipulation
-    }
-
     /// @notice             Supplies liquidity in float, locking it until claimed
     /// @param poolId       Keccak256 hash of the engine address and pool parameters (strike, sigma, maturity)
     /// @param delLiquidity Amount of liquidity to supply
@@ -83,11 +72,32 @@ library Position {
         position.liquidity += delLiquidity.toUint128();
     }
 
-    /// @notice             Reduces Position debt
+    /// @notice             Increases collateral balances of the Position from increasing liquidity debt
+    /// @param poolId       Keccak256 hash of the engine address and pool parameters (strike, sigma, maturity)
+    /// @param riskyCollateral  Amount of risky to hold as collateral for risky / 1 = units of debt
+    /// @param stableCollateral Amount of stable to hold as collateral for stable / K = units of debt
+    function borrow(
+        mapping(bytes32 => Data) storage positions,
+        bytes32 poolId,
+        uint256 riskyCollateral,
+        uint256 stableCollateral
+    ) internal returns (Data storage position) {
+        position = fetch(positions, msg.sender, poolId);
+        if (riskyCollateral > 0) position.riskyCollateral += riskyCollateral.toUint128();
+        if (stableCollateral > 0) position.stableCollateral += stableCollateral.toUint128();
+    }
+
+    /// @notice             Reduces Position's collateral balance, by reducing liquidity debt
     /// @param position     Position in state to manipulate
-    /// @param delLiquidity Amount of debt to reduce from the Position
-    function repay(Data storage position, uint256 delLiquidity) internal {
-        position.debt -= delLiquidity.toUint128();
+    /// @param riskyCollateral  Amount of risky collateral to liquidate by repaying risky / 1 = units of debt
+    /// @param stableCollateral Amount of stable collateral to liquidate by repaying stable / K = units of debt
+    function repay(
+        Data storage position,
+        uint256 riskyCollateral,
+        uint256 stableCollateral
+    ) internal {
+        if (riskyCollateral > 0) position.riskyCollateral -= riskyCollateral.toUint128();
+        if (stableCollateral > 0) position.stableCollateral -= stableCollateral.toUint128();
     }
 
     /// @notice             Fetches the position Id

--- a/contracts/test/engine/EngineCreate.sol
+++ b/contracts/test/engine/EngineCreate.sol
@@ -51,7 +51,8 @@ contract EngineCreate {
         returns (
             uint128 float,
             uint128 liquidity,
-            uint128 debt
+            uint128 riskyCollateral,
+            uint128 stableCollateral
         )
     {
         return IPrimitiveEngine(engine).positions(keccak256(abi.encodePacked(address(this), pid)));

--- a/contracts/test/engine/EngineRepay.sol
+++ b/contracts/test/engine/EngineRepay.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.6;
 import "../../interfaces/IPrimitiveEngine.sol";
 import "../../interfaces/IERC20.sol";
 
+import "hardhat/console.sol";
+
 contract EngineRepay {
     address public engine;
     address public risky;
@@ -28,80 +30,103 @@ contract EngineRepay {
     function borrow(
         bytes32 poolId,
         address owner,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bytes calldata data
     ) public {
         owner;
         CALLER = msg.sender;
-        IPrimitiveEngine(engine).borrow(poolId, delLiquidity, false, data);
+        IPrimitiveEngine(engine).borrow(poolId, riskyCollateral, stableCollateral, false, data);
+    }
+
+    function borrowWithMargin(
+        bytes32 poolId,
+        address owner,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
+        bytes calldata data
+    ) public {
+        owner;
+        CALLER = msg.sender;
+        IPrimitiveEngine(engine).borrow(poolId, riskyCollateral, stableCollateral, true, data);
     }
 
     function borrowMaxPremium(
         bytes32 poolId,
         address owner,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bytes calldata data
     ) public {
         owner;
         CALLER = msg.sender;
-        IPrimitiveEngine(engine).borrow(poolId, delLiquidity, false, data);
+        IPrimitiveEngine(engine).borrow(poolId, riskyCollateral, stableCollateral, false, data);
     }
 
     function borrowWithoutPaying(
         bytes32 poolId,
         address owner,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bytes calldata data
     ) public {
         owner;
         CALLER = msg.sender;
         dontPay = 0;
-        IPrimitiveEngine(engine).borrow(poolId, delLiquidity, false, data);
+        IPrimitiveEngine(engine).borrow(poolId, riskyCollateral, stableCollateral, false, data);
         dontPay = 1;
     }
 
     function borrowCallback(
-        uint256 delLiquidity,
-        uint256 delRisky,
-        uint256 delStable,
+        uint256 riskyDeficit,
+        uint256 stableDeficit,
         bytes calldata data
     ) public {
         data;
-        uint256 riskyNeeded = delLiquidity - delRisky;
         if (dontPay == 0) return;
-        IERC20(risky).transferFrom(CALLER, msg.sender, riskyNeeded);
-        IERC20(stable).transfer(CALLER, delStable);
+        if (riskyDeficit > 0) IERC20(risky).transferFrom(CALLER, msg.sender, riskyDeficit);
+        if (stableDeficit > 0) IERC20(stable).transferFrom(CALLER, msg.sender, stableDeficit);
+        IERC20(risky).transfer(CALLER, IERC20(risky).balanceOf(address(this)));
+        IERC20(stable).transfer(CALLER, IERC20(stable).balanceOf(address(this)));
     }
 
     function repay(
         bytes32 poolId,
         address owner,
-        uint256 delLiquidity,
+        uint256 riskyToLiquidate,
+        uint256 stableToLiquidate,
         bool fromMargin,
         bytes calldata data
     ) external {
         CALLER = msg.sender;
-        IPrimitiveEngine(engine).repay(poolId, owner, delLiquidity, fromMargin, data);
+        IPrimitiveEngine(engine).repay(poolId, owner, riskyToLiquidate, stableToLiquidate, fromMargin, data);
     }
 
     function repayWithoutRepaying(
         bytes32 poolId,
         address owner,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bool fromMargin,
         bytes calldata data
     ) external {
         CALLER = msg.sender;
         dontRepay = 0;
-        IPrimitiveEngine(engine).repay(poolId, owner, delLiquidity, fromMargin, data);
+        IPrimitiveEngine(engine).repay(poolId, owner, riskyCollateral, stableCollateral, fromMargin, data);
         dontRepay = 1;
     }
 
-    function repayCallback(uint256 delStable, bytes calldata data) external {
+    function repayCallback(
+        uint256 riskyDeficit,
+        uint256 stableDeficit,
+        bytes calldata data
+    ) external {
         data;
         if (dontRepay == 0) return;
-        IERC20(stable).transferFrom(CALLER, msg.sender, delStable);
+        if (riskyDeficit > 0) IERC20(risky).transferFrom(CALLER, msg.sender, (riskyDeficit));
+        if (stableDeficit > 0) IERC20(stable).transferFrom(CALLER, msg.sender, (stableDeficit));
         IERC20(risky).transfer(CALLER, IERC20(risky).balanceOf(address(this)));
+        IERC20(stable).transfer(CALLER, IERC20(stable).balanceOf(address(this)));
     }
 
     function getPosition(bytes32 poolId) public view returns (bytes32 posid) {
@@ -109,6 +134,6 @@ contract EngineRepay {
     }
 
     function name() public pure returns (string memory) {
-        return "EngineRepay";
+        return "EngineBorrow";
     }
 }

--- a/contracts/test/engine/ReentrancyAttacker.sol
+++ b/contracts/test/engine/ReentrancyAttacker.sol
@@ -15,6 +15,10 @@ contract ReentrancyAttacker {
     uint256 private _maturity;
     uint256 private _delta;
     uint256 private _delLiquidity;
+    uint256 private _riskyCollateral;
+    uint256 private _stableCollateral;
+    uint256 private _riskyDeficit;
+    uint256 private _stableDeficit;
     bytes32 private _poolId;
     address private _owner;
 
@@ -127,55 +131,59 @@ contract ReentrancyAttacker {
     function borrow(
         bytes32 poolId,
         address owner,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bytes calldata data
     ) public {
         CALLER = msg.sender;
 
         _poolId = poolId;
         _owner = owner;
-        _delLiquidity = delLiquidity;
+        _riskyCollateral = riskyCollateral;
+        _stableCollateral = stableCollateral;
 
-        IPrimitiveEngine(engine).borrow(poolId, delLiquidity, false, data);
+        IPrimitiveEngine(engine).borrow(poolId, riskyCollateral, stableCollateral, false, data);
     }
 
     function borrowWithGoodCallback(
         bytes32 poolId,
         address owner,
-        uint256 delLiquidity,
+        uint256 riskyCollateral,
+        uint256 stableCollateral,
         bytes calldata data
     ) public {
         CALLER = msg.sender;
 
         _poolId = poolId;
         _owner = owner;
-        _delLiquidity = delLiquidity;
+        _riskyCollateral = riskyCollateral;
+        _stableCollateral = stableCollateral;
 
         _goodCallback = true;
-        IPrimitiveEngine(engine).borrow(poolId, delLiquidity, false, data);
+        IPrimitiveEngine(engine).borrow(poolId, riskyCollateral, stableCollateral, false, data);
         _goodCallback = false;
     }
 
     function borrowCallback(
-        uint256 delLiquidity,
-        uint256 delRisky,
-        uint256 delStable,
+        uint256 riskyDeficit,
+        uint256 stableDeficit,
         bytes calldata data
     ) public {
-        uint256 riskyNeeded = delLiquidity - delRisky;
-
         if (_goodCallback) {
-            IERC20(risky).transferFrom(CALLER, msg.sender, riskyNeeded);
-            IERC20(stable).transfer(CALLER, delStable);
+            if (riskyDeficit > 0) IERC20(risky).transferFrom(CALLER, msg.sender, riskyDeficit);
+            if (stableDeficit > 0) IERC20(stable).transferFrom(CALLER, msg.sender, stableDeficit);
+            IERC20(risky).transfer(CALLER, IERC20(risky).balanceOf(address(this)));
+            IERC20(stable).transfer(CALLER, IERC20(stable).balanceOf(address(this)));
         } else {
-            IPrimitiveEngine(engine).borrow(_poolId, _delLiquidity, false, data);
+            IPrimitiveEngine(engine).borrow(_poolId, _riskyCollateral, _stableCollateral, false, data);
         }
     }
 
     function repay(
         bytes32 poolId,
         address owner,
-        uint256 delLiquidity,
+        uint256 riskyToLiquidate,
+        uint256 stableToLiquidate,
         bool fromMargin,
         bytes calldata data
     ) external {
@@ -183,13 +191,17 @@ contract ReentrancyAttacker {
 
         _poolId = poolId;
         _owner = owner;
-        _delLiquidity = delLiquidity;
 
-        IPrimitiveEngine(engine).repay(poolId, owner, delLiquidity, fromMargin, data);
+        IPrimitiveEngine(engine).repay(poolId, owner, riskyToLiquidate, stableToLiquidate, fromMargin, data);
     }
 
-    function repayCallback(uint256 delStable, bytes calldata data) external {
-        delStable;
-        IPrimitiveEngine(engine).repay(_poolId, _owner, _delLiquidity, false, data);
+    function repayCallback(
+        uint256 riskyDeficit,
+        uint256 stableDeficit,
+        bytes calldata data
+    ) external {
+        riskyDeficit;
+        stableDeficit;
+        IPrimitiveEngine(engine).repay(_poolId, _owner, riskyDeficit, stableDeficit, false, data);
     }
 }

--- a/contracts/test/libraries/TestPosition.sol
+++ b/contracts/test/libraries/TestPosition.sol
@@ -30,7 +30,8 @@ contract TestPosition {
         positions[posId] = Position.Data({
             float: 0,
             liquidity: uint128(liquidity), // init with {liquidity} units of liquidity
-            debt: 0
+            riskyCollateral: 0,
+            stableCollateral: 0
         });
 
         Position.Data memory position = positions.fetch(msg.sender, poolId);
@@ -66,16 +67,6 @@ contract TestPosition {
         assert(post + uint128(amount) >= pre);
     }
 
-    /// @notice Increments debt for a position
-    function shouldBorrow(bytes32 poolId, uint256 amount) public {
-        Position.Data memory position = _shouldFetch(msg.sender, poolId);
-        uint128 pre = position.debt;
-        positions.borrow(poolId, amount);
-        position = _shouldFetch(msg.sender, poolId);
-        uint128 post = position.debt;
-        assert(post >= uint128(amount) + pre);
-    }
-
     /// @notice Increments a position's float
     function shouldSupply(bytes32 poolId, uint256 amount) public {
         Position.Data memory position = _shouldFetch(msg.sender, poolId);
@@ -96,14 +87,38 @@ contract TestPosition {
         assert(post + uint128(amount) >= pre);
     }
 
-    /// @notice Decrements a position's debt by reducing its liquidity
-    function shouldRepay(bytes32 poolId, uint256 amount) public {
+    /// @notice Increments debt for a position
+    function shouldBorrow(
+        bytes32 poolId,
+        uint256 riskyCollateral,
+        uint256 stableCollateral
+    ) public {
         Position.Data memory position = _shouldFetch(msg.sender, poolId);
-        uint128 pre = position.debt;
-        positions.fetch(msg.sender, poolId).repay(amount);
+        uint128 preRisky = position.riskyCollateral;
+        uint128 preStable = position.stableCollateral;
+        positions.borrow(poolId, riskyCollateral, stableCollateral);
         position = _shouldFetch(msg.sender, poolId);
-        uint128 debt = position.debt;
-        assert(debt + uint128(amount) >= pre);
+        uint128 postRisky = position.riskyCollateral;
+        uint128 postStable = position.stableCollateral;
+        assert(postRisky >= uint128(riskyCollateral) + preRisky);
+        assert(postStable >= uint128(stableCollateral) + preStable);
+    }
+
+    /// @notice Decrements a position's debt by reducing its liquidity
+    function shouldRepay(
+        bytes32 poolId,
+        uint256 riskyToLiquidate,
+        uint256 stableToLiquidate
+    ) public {
+        Position.Data memory position = _shouldFetch(msg.sender, poolId);
+        uint128 preRisky = position.riskyCollateral;
+        uint128 preStable = position.stableCollateral;
+        positions.fetch(msg.sender, poolId).repay(riskyToLiquidate, stableToLiquidate);
+        position = _shouldFetch(msg.sender, poolId);
+        uint128 riskyCollateral = position.riskyCollateral;
+        uint128 stableCollateral = position.stableCollateral;
+        assert(riskyCollateral + uint128(riskyToLiquidate) >= preRisky);
+        assert(stableCollateral + uint128(stableToLiquidate) >= preStable);
     }
 
     /// @return positionId The keccak256 hash of `where` `owner` and `poolId` is the position id

--- a/test/shared/matchers/supportPosition.ts
+++ b/test/shared/matchers/supportPosition.ts
@@ -88,38 +88,66 @@ export default function supportPosition(Assertion: Chai.AssertionStatic) {
 
   Assertion.addMethod(
     'increasePositionDebt',
-    async function (this: any, engine: PrimitiveEngine, posId: string, debt: BigNumber) {
+    async function (
+      this: any,
+      engine: PrimitiveEngine,
+      posId: string,
+      riskyCollateral: BigNumber,
+      stableCollateral: BigNumber
+    ) {
       const oldPosition = await engine.positions(posId)
       await this._obj
       const newPosition = await engine.positions(posId)
 
-      const expectedDebt = oldPosition.debt.add(debt)
+      const expectedRiskyCollateral = oldPosition.riskyCollateral.add(riskyCollateral)
+      const expectedStableCollateral = oldPosition.stableCollateral.add(stableCollateral)
 
       this.assert(
-        newPosition.debt.eq(expectedDebt),
-        `Expected ${newPosition.debt} to be ${expectedDebt}`,
-        `Expected ${newPosition.debt} NOT to be ${expectedDebt}`,
-        expectedDebt,
-        newPosition.debt
+        newPosition.riskyCollateral.eq(expectedRiskyCollateral),
+        `Expected ${newPosition.riskyCollateral} to be ${expectedRiskyCollateral}`,
+        `Expected ${newPosition.riskyCollateral} NOT to be ${expectedRiskyCollateral}`,
+        expectedRiskyCollateral,
+        newPosition.riskyCollateral
+      )
+      this.assert(
+        newPosition.stableCollateral.eq(expectedStableCollateral),
+        `Expected ${newPosition.stableCollateral} to be ${expectedStableCollateral}`,
+        `Expected ${newPosition.stableCollateral} NOT to be ${expectedStableCollateral}`,
+        expectedStableCollateral,
+        newPosition.stableCollateral
       )
     }
   )
 
   Assertion.addMethod(
     'decreasePositionDebt',
-    async function (this: any, engine: PrimitiveEngine, posId: string, debt: BigNumber) {
+    async function (
+      this: any,
+      engine: PrimitiveEngine,
+      posId: string,
+      riskyCollateral: BigNumber,
+      stableCollateral: BigNumber
+    ) {
       const oldPosition = await engine.positions(posId)
       await this._obj
       const newPosition = await engine.positions(posId)
 
-      const expectedDebt = oldPosition.debt.sub(debt)
+      const expectedRiskyCollateral = oldPosition.riskyCollateral.sub(riskyCollateral)
+      const expectedStableCollateral = oldPosition.stableCollateral.sub(stableCollateral)
 
       this.assert(
-        newPosition.debt.eq(expectedDebt),
-        `Expected ${newPosition.debt} to be ${expectedDebt}`,
-        `Expected ${newPosition.debt} NOT to be ${expectedDebt}`,
-        expectedDebt,
-        newPosition.debt
+        newPosition.riskyCollateral.eq(expectedRiskyCollateral),
+        `Expected ${newPosition.riskyCollateral} to be ${expectedRiskyCollateral}`,
+        `Expected ${newPosition.riskyCollateral} NOT to be ${expectedRiskyCollateral}`,
+        expectedRiskyCollateral,
+        newPosition.riskyCollateral
+      )
+      this.assert(
+        newPosition.stableCollateral.eq(expectedStableCollateral),
+        `Expected ${newPosition.stableCollateral} to be ${expectedStableCollateral}`,
+        `Expected ${newPosition.stableCollateral} NOT to be ${expectedStableCollateral}`,
+        expectedStableCollateral,
+        newPosition.stableCollateral
       )
     }
   )

--- a/test/unit/libraries/position.ts
+++ b/test/unit/libraries/position.ts
@@ -39,9 +39,10 @@ describe('testPosition', function () {
       let amount = parseWei('0.1').raw
       await position.shouldRemove(poolId, (await position.pos()).liquidity) // remove all liq so we can borrow
       expect((await position.pos()).liquidity).to.be.eq(0) // liq must be 0 to borrow
-      await position.shouldBorrow(poolId, amount)
+      await position.shouldBorrow(poolId, amount, amount)
       expect((await position.pos()).liquidity).to.be.deep.eq(0) // removed all liquidity
-      expect((await position.pos()).debt).to.be.deep.eq(before.debt.add(amount))
+      expect((await position.pos()).riskyCollateral).to.be.deep.eq(before.riskyCollateral.add(amount))
+      expect((await position.pos()).stableCollateral).to.be.deep.eq(before.stableCollateral.add(amount))
     })
     it('shouldSupply', async function () {
       let amount = parseWei('0.1').raw
@@ -59,10 +60,11 @@ describe('testPosition', function () {
     it('shouldRepay', async function () {
       let amount = parseWei('0.1').raw
       await position.shouldRemove(poolId, (await position.pos()).liquidity) // remove all liq so we can borrow
-      await position.shouldBorrow(poolId, amount)
-      await position.shouldRepay(poolId, amount) // borrow from this account so we can repay
+      await position.shouldBorrow(poolId, amount, amount)
+      await position.shouldRepay(poolId, amount, amount) // borrow from this account so we can repay
       expect((await position.pos()).liquidity).to.be.deep.eq(0)
-      expect((await position.pos()).debt).to.be.deep.eq(before.debt) // no change
+      expect((await position.pos()).riskyCollateral).to.be.deep.eq(before.riskyCollateral) // no change
+      expect((await position.pos()).stableCollateral).to.be.deep.eq(before.stableCollateral) // no change
     })
     it('shouldGetPositionId', async function () {
       expect(await position.shouldGetPositionId(this.signers[0].address, poolId)).to.be.deep.eq(

--- a/test/unit/primitiveEngine/effect/borrow.ts
+++ b/test/unit/primitiveEngine/effect/borrow.ts
@@ -44,117 +44,242 @@ describe('borrow', function () {
     })
 
     describe('success cases', async function () {
-      it('pos.borrow: increases position debt', async function () {
-        await expect(engineBorrow.borrow(poolId, engineBorrow.address, one.raw, HashZero)).to.increasePositionDebt(
+      it('pos.borrow: increases position riskyCollateral', async function () {
+        await expect(engineBorrow.borrow(poolId, engineBorrow.address, one.raw, '0', HashZero)).to.increasePositionDebt(
           engine,
           posId,
-          one.raw
+          one.raw,
+          toBN('0')
         )
-        expect(await engine.positions(posId)).to.be.deep.eq([parseWei('0').raw, parseWei('0').raw, one.raw])
+        expect(await engine.positions(posId)).to.be.deep.eq([toBN(0), toBN(0), one.raw, toBN('0')])
       })
-      it('res.borrowFloat: increases reserve debt', async function () {
-        await expect(engineBorrow.borrow(poolId, engineBorrow.address, one.raw, HashZero)).to.increaseReserveDebt(
+
+      it('pos.borrow: increases position stableCollateral', async function () {
+        await expect(engineBorrow.borrow(poolId, engineBorrow.address, '0', strike.raw, HashZero)).to.increasePositionDebt(
           engine,
-          poolId,
-          one.raw
+          posId,
+          toBN('0'),
+          strike.raw
         )
+        expect(await engine.positions(posId)).to.be.deep.eq([toBN(0), toBN(0), toBN('0'), strike.raw])
+      })
+
+      it('pos.borrow: increases position risky & stable collateral', async function () {
+        await expect(
+          engineBorrow.borrow(poolId, engineBorrow.address, one.raw, strike.raw, HashZero)
+        ).to.increasePositionDebt(engine, posId, one.raw, strike.raw)
+        expect(await engine.positions(posId)).to.be.deep.eq([toBN(0), toBN(0), one.raw, strike.raw])
+      })
+
+      it('res.borrowFloat: increases reserve debt', async function () {
+        const riskyCollateral = one
+        const stableCollateral = strike
+        const delLiquidity = riskyCollateral.add(stableCollateral.mul(1e18).div(strike))
+        await expect(
+          engineBorrow.borrow(poolId, engineBorrow.address, riskyCollateral.raw, stableCollateral.raw, HashZero)
+        ).to.increaseReserveDebt(engine, poolId, delLiquidity.raw)
       })
 
       it('res.borrowFloat: decreases reserve float', async function () {
-        await expect(engineBorrow.borrow(poolId, engineBorrow.address, one.raw, HashZero)).to.decreaseReserveFloat(
-          engine,
-          poolId,
-          one.raw
-        )
+        const riskyCollateral = one
+        const stableCollateral = strike
+        const delLiquidity = riskyCollateral.add(stableCollateral.mul(1e18).div(strike))
+        await expect(
+          engineBorrow.borrow(poolId, engineBorrow.address, riskyCollateral.raw, stableCollateral.raw, HashZero)
+        ).to.decreaseReserveFloat(engine, poolId, delLiquidity.raw)
       })
 
       it('res.remove: decreases reserve liquidity', async function () {
-        await expect(engineBorrow.borrow(poolId, engineBorrow.address, one.raw, HashZero)).to.decreaseReserveLiquidity(
-          engine,
-          poolId,
-          one.raw
-        )
+        const riskyCollateral = one
+        const stableCollateral = strike
+        const delLiquidity = riskyCollateral.add(stableCollateral.mul(1e18).div(strike))
+        await expect(
+          engineBorrow.borrow(poolId, engineBorrow.address, riskyCollateral.raw, stableCollateral.raw, HashZero)
+        ).to.decreaseReserveLiquidity(engine, poolId, delLiquidity.raw)
       })
 
-      it('res.remove: decreases reserve risky', async function () {
+      it('res.remove: decreases reserve risky from riskyCollateral', async function () {
         const res = await this.contracts.engine.reserves(poolId)
         const delRisky = one.raw.mul(res.reserveRisky).div(res.liquidity)
-        await expect(engineBorrow.borrow(poolId, engineBorrow.address, one.raw, HashZero)).to.decreaseReserveRisky(
+        await expect(engineBorrow.borrow(poolId, engineBorrow.address, one.raw, '0', HashZero)).to.decreaseReserveRisky(
           engine,
           poolId,
           delRisky
         )
       })
 
-      it('res.remove: decreases reserve stable', async function () {
+      it('res.remove: decreases reserve stable from riskyCollateral', async function () {
         const res = await this.contracts.engine.reserves(poolId)
         const delStable = one.raw.mul(res.reserveStable).div(res.liquidity)
-        await expect(engineBorrow.borrow(poolId, engineBorrow.address, one.raw, HashZero)).to.decreaseReserveStable(
+        await expect(engineBorrow.borrow(poolId, engineBorrow.address, one.raw, '0', HashZero)).to.decreaseReserveStable(
           engine,
           poolId,
           delStable
         )
       })
 
-      it('borrows using margin', async function () {
+      it('res.remove: decreases reserve risky from stableCollateral', async function () {
+        const res = await this.contracts.engine.reserves(poolId)
+        const stableCollateral = strike
+        const delLiquidity = stableCollateral.mul(1e18).div(strike)
+        const delRisky = delLiquidity.mul(res.reserveRisky).div(res.liquidity).raw
+        await expect(
+          engineBorrow.borrow(poolId, engineBorrow.address, '0', stableCollateral.raw, HashZero)
+        ).to.decreaseReserveRisky(engine, poolId, delRisky)
+      })
+
+      it('res.remove: decreases reserve stable from stableCollateral', async function () {
+        const res = await this.contracts.engine.reserves(poolId)
+        const stableCollateral = strike
+        const delLiquidity = stableCollateral.mul(1e18).div(strike)
+        const delStable = delLiquidity.mul(res.reserveStable).div(res.liquidity).raw
+        await expect(
+          engineBorrow.borrow(poolId, engineBorrow.address, '0', stableCollateral.raw, HashZero)
+        ).to.decreaseReserveStable(engine, poolId, delStable)
+      })
+
+      it('borrows riskyCollateral using margin', async function () {
         const res = await this.contracts.engine.reserves(poolId)
         const delRisky = one.raw.mul(res.reserveRisky).div(res.liquidity)
         const delStable = one.raw.mul(res.reserveStable).div(res.liquidity)
-        const premium = one.raw.sub(delRisky)
-        await this.contracts.engineDeposit.deposit(engineBorrow.address, premium, delStable, HashZero)
-        await expect(engineBorrow.borrowWithMargin(poolId, engineBorrow.address, one.raw, HashZero)).to.decreaseMargin(
+        const riskyDeficit = one.sub(delRisky).raw
+        await this.contracts.engineDeposit.deposit(engineBorrow.address, riskyDeficit, delStable, HashZero)
+        await expect(engineBorrow.borrowWithMargin(poolId, engineBorrow.address, one.raw, '0', HashZero)).to.decreaseMargin(
           engine,
           engineBorrow.address,
-          premium,
+          riskyDeficit,
           delStable.mul(-1)
         )
       })
 
-      it('msg.sender recieves stable tokens from removed liquidity', async function () {
+      it('borrows stableCollateral using margin', async function () {
+        const res = await this.contracts.engine.reserves(poolId)
+        const delRisky = one.raw.mul(res.reserveRisky).div(res.liquidity)
+        const delStable = one.raw.mul(res.reserveStable).div(res.liquidity)
+        const stableDeficit = strike.sub(delStable).raw
+        await this.contracts.engineDeposit.deposit(engineBorrow.address, stableDeficit, stableDeficit, HashZero)
+        await expect(
+          engineBorrow.borrowWithMargin(poolId, engineBorrow.address, '0', strike.raw, HashZero)
+        ).to.decreaseMargin(engine, engineBorrow.address, delRisky.mul(-1), stableDeficit)
+      })
+
+      it('borrows risky & stable collateral using margin', async function () {
+        const res = await this.contracts.engine.reserves(poolId)
+        const delLiquidity = one.add(strike.mul(1e18).div(strike))
+        const delRisky = delLiquidity.mul(res.reserveRisky).div(res.liquidity).raw
+        const delStable = delLiquidity.mul(res.reserveStable).div(res.liquidity).raw
+        const riskyDeficit = one.sub(delRisky)
+        const stableDeficit = strike.sub(delStable)
+
+        await this.contracts.engineDeposit.deposit(engineBorrow.address, riskyDeficit.raw, stableDeficit.raw, HashZero)
+
+        await expect(
+          engineBorrow.borrowWithMargin(poolId, engineBorrow.address, one.raw, strike.raw, HashZero)
+        ).to.decreaseMargin(engine, engineBorrow.address, riskyDeficit.raw, stableDeficit.raw)
+      })
+
+      it('msg.sender receives stable tokens from removed liquidity', async function () {
         const res = await this.contracts.engine.reserves(poolId)
         const delStable = one.raw.mul(res.reserveStable).div(res.liquidity)
-        await expect(() => engineBorrow.borrow(poolId, engineBorrow.address, one.raw, HashZero)).to.changeTokenBalances(
+        await expect(() => engineBorrow.borrow(poolId, engineBorrow.address, one.raw, '0', HashZero)).to.changeTokenBalances(
           this.contracts.stable,
           [this.signers[0]],
           [delStable]
         )
       })
 
-      it('engine recieves risky token premium', async function () {
+      it('msg.sender receives risky tokens from removed liquidity', async function () {
         const res = await this.contracts.engine.reserves(poolId)
         const delRisky = one.raw.mul(res.reserveRisky).div(res.liquidity)
-        const premium = one.raw.sub(delRisky)
-        await expect(() => engineBorrow.borrow(poolId, engineBorrow.address, one.raw, HashZero)).to.changeTokenBalances(
+        await expect(() =>
+          engineBorrow.borrow(poolId, engineBorrow.address, '0', strike.raw, HashZero)
+        ).to.changeTokenBalances(this.contracts.risky, [this.signers[0]], [delRisky])
+      })
+
+      it('engine receives risky token surplus', async function () {
+        const res = await this.contracts.engine.reserves(poolId)
+        const delRisky = one.raw.mul(res.reserveRisky).div(res.liquidity)
+        const riskySurplus = one.raw.sub(delRisky)
+        await expect(() => engineBorrow.borrow(poolId, engineBorrow.address, one.raw, '0', HashZero)).to.changeTokenBalances(
           this.contracts.risky,
           [this.contracts.engine],
-          [premium]
+          [riskySurplus]
         )
       })
 
-      it('repays a long option position, earning the proceeds', async function () {
+      it('engine receives stable token surplus', async function () {
+        const res = await this.contracts.engine.reserves(poolId)
+        const delStable = one.raw.mul(res.reserveStable).div(res.liquidity)
+        const stableSurplus = strike.sub(delStable).raw
+        await expect(() =>
+          engineBorrow.borrow(poolId, engineBorrow.address, '0', strike.raw, HashZero)
+        ).to.changeTokenBalances(this.contracts.stable, [this.contracts.engine], [stableSurplus])
+      })
+
+      it('repays a long option position with risky collateral, earning the proceeds', async function () {
         let riskyBal = await this.contracts.risky.balanceOf(deployer.address)
-        await engineBorrow.borrow(poolId, engineBorrow.address, one.raw, HashZero) // spends premium
+        await engineBorrow.borrow(poolId, engineBorrow.address, one.raw, '0', HashZero) // spends premium
         let premium = riskyBal.sub(await this.contracts.risky.balanceOf(deployer.address))
         await expect(() =>
-          engineBorrow.repay(poolId, engineBorrow.address, one.raw, false, HashZero)
+          engineBorrow.repay(poolId, engineBorrow.address, one.raw, '0', false, HashZero)
         ).to.changeTokenBalances(this.contracts.risky, [deployer], [premium])
-        expect(await engine.positions(posId)).to.be.deep.eq([parseWei('0').raw, parseWei('0').raw, parseWei('0').raw])
+        expect(await engine.positions(posId)).to.be.deep.eq([toBN(0), toBN(0), toBN(0), toBN(0)])
+      })
+
+      it('repays a long option position with stable collateral, earning the proceeds', async function () {
+        let stableBal = await this.contracts.stable.balanceOf(deployer.address)
+        const stableCollateral = strike
+        await engineBorrow.borrow(poolId, engineBorrow.address, '0', stableCollateral.raw, HashZero) // spends premium
+        const stableSurplus = stableBal.sub(await this.contracts.stable.balanceOf(deployer.address))
+        await expect(() =>
+          engineBorrow.repay(poolId, engineBorrow.address, '0', stableCollateral.raw, false, HashZero)
+        ).to.changeTokenBalances(this.contracts.stable, [deployer], [stableSurplus])
+        expect(await engine.positions(posId)).to.be.deep.eq([toBN(0), toBN(0), toBN(0), toBN(0)])
+      })
+
+      it('emits the Borrowed event', async function () {
+        const res = await this.contracts.engine.reserves(poolId)
+        const delRisky = one.mul(res.reserveRisky).div(res.liquidity)
+        const delStable = one.mul(res.reserveStable).div(res.liquidity)
+        await expect(this.contracts.engineBorrow.borrow(poolId, this.contracts.engineBorrow.address, one.raw, '0', HashZero))
+          .to.emit(this.contracts.engine, 'Borrowed')
+          .withArgs(
+            this.contracts.engineBorrow.address,
+            poolId,
+            one.raw,
+            '0',
+            one.sub(delRisky).raw, // riskyDeficit
+            '0', // riskySurplus
+            '0', // stableDeficit
+            delStable.raw // stableSurplus
+          )
       })
     })
 
     describe('fail cases', async function () {
-      it('reverts if borrow amount is 0', async function () {
-        await expect(engineBorrow.borrow(poolId, engineBorrow.address, parseWei('0').raw, HashZero)).to.be.reverted
+      it('reverts if both risky & stable collateral amounts are 0', async function () {
+        await expect(engineBorrow.borrow(poolId, engineBorrow.address, toBN(0), toBN(0), HashZero)).to.be.reverted
       })
       it('fails to originate more long option positions than are allocated to float', async function () {
-        await expect(engineBorrow.borrow(poolId, engineBorrow.address, parseWei('2000').raw, HashZero)).to.be.reverted
-      })
-      it('fails to originate 1 long option, because no tokens were paid', async function () {
-        await expect(engineBorrow.borrowWithoutPaying(poolId, engineBorrow.address, one.raw, HashZero)).to.be.reverted
+        await expect(engineBorrow.borrow(poolId, engineBorrow.address, parseWei('2000').raw, toBN(0), HashZero)).to.be
+          .reverted
       })
 
-      it('fails to borrow from margin because not enough premium', async function () {
-        await expect(engineBorrow.borrowWithMargin(poolId, engineBorrow.address, one.raw, HashZero)).to.be.reverted
+      it('fails to originate 1 long option, because no tokens were paid for risky deficit', async function () {
+        await expect(engineBorrow.borrowWithoutPaying(poolId, engineBorrow.address, one.raw, '0', HashZero)).to.be.reverted
+      })
+
+      it('fails to originate 1 long option, because no tokens were paid for stable deficit', async function () {
+        await expect(engineBorrow.borrowWithoutPaying(poolId, engineBorrow.address, '0', strike.raw, HashZero)).to.be
+          .reverted
+      })
+
+      it('fails to borrow from margin because not enough risky in margin', async function () {
+        await expect(engineBorrow.borrowWithMargin(poolId, engineBorrow.address, one.raw, '0', HashZero)).to.be.reverted
+      })
+
+      it('fails to borrow from margin because not enough stable in margin', async function () {
+        await expect(engineBorrow.borrowWithMargin(poolId, engineBorrow.address, '0', strike.raw, HashZero)).to.be.reverted
       })
     })
   })

--- a/test/unit/primitiveEngine/effect/claim.ts
+++ b/test/unit/primitiveEngine/effect/claim.ts
@@ -62,7 +62,7 @@ describe('claim', function () {
       await expect(this.contracts.engineSupply.claim(poolId, parseWei('20').raw)).to.be.reverted
     })
     it('fails to remove more to float than is available in the __GLOBAL FLOAT__', async function () {
-      await this.contracts.engineBorrow.borrow(poolId, this.contracts.engineBorrow.address, one.raw, HashZero)
+      await this.contracts.engineBorrow.borrow(poolId, this.contracts.engineBorrow.address, one.raw, '0', HashZero)
       await expect(this.contracts.engineSupply.claim(poolId, one.raw)).to.be.reverted
     })
   })

--- a/test/unit/primitiveEngine/effect/reentrancy.ts
+++ b/test/unit/primitiveEngine/effect/reentrancy.ts
@@ -87,8 +87,9 @@ describe('reentrancy', function () {
     })
 
     it('reverts the transaction', async function () {
-      await expect(this.contracts.reentrancyAttacker.borrow(poolId, this.signers[0].address, parseWei('1').raw, HashZero)).to
-        .be.reverted
+      await expect(
+        this.contracts.reentrancyAttacker.borrow(poolId, this.signers[0].address, parseWei('1').raw, '0', HashZero)
+      ).to.be.reverted
     })
   })
 
@@ -113,6 +114,7 @@ describe('reentrancy', function () {
         poolId,
         this.contracts.reentrancyAttacker.address,
         parseWei('1').raw,
+        '0',
         HashZero
       )
     })
@@ -123,6 +125,7 @@ describe('reentrancy', function () {
           poolId,
           this.contracts.reentrancyAttacker.address,
           parseWei('1').raw,
+          '0',
           false,
           HashZero
         )

--- a/test/unit/primitiveEngine/effect/repay.ts
+++ b/test/unit/primitiveEngine/effect/repay.ts
@@ -1,6 +1,6 @@
 import expect from '../../../shared/expect'
 import { waffle } from 'hardhat'
-import { parseWei, Time, toBN } from 'web3-units'
+import { parseWei, Time, toBN, Wei } from 'web3-units'
 import { constants, Wallet } from 'ethers'
 
 import loadContext, { DEFAULT_CONFIG as config } from '../../context'
@@ -19,7 +19,7 @@ export async function beforeEachRepay(signers: Wallet[], contracts: Contracts): 
   const initLiquidity = parseWei('100')
   await contracts.engineAllocate.allocateFromExternal(poolId, contracts.engineSupply.address, initLiquidity.raw, HashZero)
   await contracts.engineSupply.supply(poolId, initLiquidity.mul(8).div(10).raw)
-  await contracts.engineRepay.borrow(poolId, contracts.engineRepay.address, parseWei('1').raw, HashZero)
+  await contracts.engineRepay.borrow(poolId, contracts.engineRepay.address, parseWei('1').raw, strike.raw, HashZero)
 }
 
 describe('repay', function () {
@@ -32,99 +32,169 @@ describe('repay', function () {
   })
 
   let poolId: string, posId: string
+  let riskyCollateral: Wei, stableCollateral: Wei, delLiquidity: Wei
   const one = parseWei('1')
 
   beforeEach(async function () {
     poolId = computePoolId(this.contracts.engine.address, maturity.raw, sigma.raw, strike.raw)
     posId = await this.contracts.engineRepay.getPosition(poolId)
+    riskyCollateral = one
+    stableCollateral = strike
+    delLiquidity = riskyCollateral.add(stableCollateral.mul(1e18).div(strike))
   })
 
   describe('success cases', function () {
-    it('reduces the debt of the position', async function () {
+    it('reduces the riskyCollateral of the position', async function () {
       await expect(
-        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
-      ).to.decreasePositionDebt(this.contracts.engine, posId, one.raw)
+        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, '0', false, HashZero)
+      ).to.decreasePositionDebt(this.contracts.engine, posId, one.raw, toBN(0))
       const position = await this.contracts.engine.positions(posId)
-      expect(position.debt).to.equal(0)
+      expect(position.riskyCollateral).to.equal(0)
+    })
+
+    it('reduces the stableCollateral of the position', async function () {
+      await expect(
+        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, '0', strike.raw, false, HashZero)
+      ).to.decreasePositionDebt(this.contracts.engine, posId, toBN(0), strike.raw)
+      const position = await this.contracts.engine.positions(posId)
+      expect(position.stableCollateral).to.equal(0)
     })
 
     it('res.allocate: increases risky reserve', async function () {
       const res = await this.contracts.engine.reserves(poolId)
-      const delRisky = one.mul(res.reserveRisky).div(res.liquidity)
+      const delRisky = delLiquidity.mul(res.reserveRisky).div(res.liquidity)
       await expect(
-        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
+        this.contracts.engineRepay.repay(
+          poolId,
+          this.contracts.engineRepay.address,
+          riskyCollateral.raw,
+          stableCollateral.raw,
+          false,
+          HashZero
+        )
       ).to.increaseReserveRisky(this.contracts.engine, poolId, delRisky.raw)
     })
 
     it('res.allocate: increases stable reserve', async function () {
       const res = await this.contracts.engine.reserves(poolId)
-      const delStable = one.mul(res.reserveStable).div(res.liquidity)
+      const delStable = delLiquidity.mul(res.reserveStable).div(res.liquidity)
       await expect(
-        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
+        this.contracts.engineRepay.repay(
+          poolId,
+          this.contracts.engineRepay.address,
+          riskyCollateral.raw,
+          stableCollateral.raw,
+          false,
+          HashZero
+        )
       ).to.increaseReserveStable(this.contracts.engine, poolId, delStable.raw)
     })
 
     it('res.allocate: increases reserve liquidity', async function () {
       await expect(
-        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
-      ).to.increaseReserveLiquidity(this.contracts.engine, poolId, one.raw)
+        this.contracts.engineRepay.repay(
+          poolId,
+          this.contracts.engineRepay.address,
+          riskyCollateral.raw,
+          stableCollateral.raw,
+          false,
+          HashZero
+        )
+      ).to.increaseReserveLiquidity(this.contracts.engine, poolId, delLiquidity.raw)
     })
 
     it('res.allocate: updates reserve blocktimestamp', async function () {
       await expect(
-        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
+        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, '0', false, HashZero)
       ).to.updateReserveBlockTimestamp(this.contracts.engine, poolId, +(await this.contracts.engine.time()))
     })
 
     it('allocates to the reserve and updates all its values', async function () {
       const oldReserve = await this.contracts.engine.reserves(poolId)
-      const delRisky = one.mul(oldReserve.reserveRisky).div(oldReserve.liquidity)
-      const delStable = one.mul(oldReserve.reserveStable).div(oldReserve.liquidity)
+      const delRisky = delLiquidity.mul(oldReserve.reserveRisky).div(oldReserve.liquidity)
+      const delStable = delLiquidity.mul(oldReserve.reserveStable).div(oldReserve.liquidity)
 
       await expect(
-        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
-      ).to.increaseReserveLiquidity(this.contracts.engine, poolId, one.raw)
+        this.contracts.engineRepay.repay(
+          poolId,
+          this.contracts.engineRepay.address,
+          riskyCollateral.raw,
+          stableCollateral.raw,
+          false,
+          HashZero
+        )
+      ).to.increaseReserveLiquidity(this.contracts.engine, poolId, delLiquidity.raw)
 
       const newReserve = await this.contracts.engine.reserves(poolId)
 
       expect(newReserve.reserveRisky).to.equal(oldReserve.reserveRisky.add(delRisky.raw))
       expect(newReserve.reserveStable).to.equal(oldReserve.reserveStable.add(delStable.raw))
-      expect(newReserve.liquidity).to.equal(oldReserve.liquidity.add(one.raw))
+      expect(newReserve.liquidity).to.equal(oldReserve.liquidity.add(delLiquidity.raw))
     })
 
     it('res.repayFloat: decreases reserve debt', async function () {
       await expect(
-        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
-      ).to.decreaseReserveDebt(this.contracts.engine, poolId, one.raw)
+        this.contracts.engineRepay.repay(
+          poolId,
+          this.contracts.engineRepay.address,
+          riskyCollateral.raw,
+          stableCollateral.raw,
+          false,
+          HashZero
+        )
+      ).to.decreaseReserveDebt(this.contracts.engine, poolId, delLiquidity.raw)
     })
 
     it('res.repayFloat: increases reserve float', async function () {
       await expect(
-        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
-      ).to.increaseReserveFloat(this.contracts.engine, poolId, one.raw)
+        this.contracts.engineRepay.repay(
+          poolId,
+          this.contracts.engineRepay.address,
+          riskyCollateral.raw,
+          stableCollateral.raw,
+          false,
+          HashZero
+        )
+      ).to.increaseReserveFloat(this.contracts.engine, poolId, delLiquidity.raw)
     })
 
     it('reduces the debt and increases the float of the reserve', async function () {
       const oldReserve = await this.contracts.engine.reserves(poolId)
 
       await expect(
-        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
-      ).to.increaseReserveFloat(this.contracts.engine, poolId, one.raw)
+        this.contracts.engineRepay.repay(
+          poolId,
+          this.contracts.engineRepay.address,
+          riskyCollateral.raw,
+          stableCollateral.raw,
+          false,
+          HashZero
+        )
+      ).to.increaseReserveFloat(this.contracts.engine, poolId, delLiquidity.raw)
 
       const newReserve = await this.contracts.engine.reserves(poolId)
-      expect(newReserve.float).to.equal(oldReserve.float.add(one.raw))
-      expect(newReserve.debt).to.equal(oldReserve.debt.sub(one.raw))
+      expect(newReserve.float).to.equal(oldReserve.float.add(delLiquidity.raw))
+      expect(newReserve.debt).to.equal(oldReserve.debt.sub(delLiquidity.raw))
     })
 
     it('emits the Repaid event', async function () {
-      await expect(this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero))
+      const res = await this.contracts.engine.reserves(poolId)
+      const delRisky = one.mul(res.reserveRisky).div(res.liquidity)
+      const delStable = one.mul(res.reserveStable).div(res.liquidity)
+      await expect(
+        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, '0', false, HashZero)
+      )
         .to.emit(this.contracts.engine, 'Repaid')
         .withArgs(
           this.contracts.engineRepay.address,
           this.contracts.engineRepay.address,
           poolId,
           one.raw,
-          parseWei(delta).raw
+          '0',
+          '0', // riskyDeficit
+          one.sub(delRisky).raw, // riskySurplus
+          delStable.raw, // stableDeficit
+          '0' // stableSurplus
         )
     })
 
@@ -139,7 +209,7 @@ describe('repay', function () {
         const margin = await this.contracts.engine.margins(this.contracts.engineRepay.address)
 
         await expect(
-          this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, true, HashZero)
+          this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, '0', true, HashZero)
         ).to.decreaseMargin(this.contracts.engine, this.contracts.engineRepay.address, premium.raw.mul(-1), delStable.raw)
 
         const newMargin = await this.contracts.engine.margins(this.contracts.engineRepay.address)
@@ -150,37 +220,56 @@ describe('repay', function () {
     })
 
     describe('when from external', function () {
-      it('transfers the premium to the caller of repay', async function () {
+      it('transfers the risky surplus to the caller of repay', async function () {
         const previousRiskyBalance = await this.contracts.risky.balanceOf(this.signers[0].address)
 
         const oldReserve = await this.contracts.engine.reserves(poolId)
-        const delRisky = one.mul(oldReserve.reserveRisky).div(oldReserve.liquidity)
-        const premium = one.sub(delRisky)
+        // div delLiquidity by 2 because we are only liquidating 1 riskyCollateral = 1 unit of debt
+        const delRisky = delLiquidity.div(2).mul(oldReserve.reserveRisky).div(oldReserve.liquidity)
+        const riskySurplus = riskyCollateral.sub(delRisky)
 
         await expect(() =>
-          this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
-        ).to.changeTokenBalances(this.contracts.risky, [this.signers[0]], [premium.raw])
+          this.contracts.engineRepay.repay(
+            poolId,
+            this.contracts.engineRepay.address,
+            riskyCollateral.raw,
+            '0',
+            false,
+            HashZero
+          )
+        ).to.changeTokenBalances(this.contracts.risky, [this.signers[0]], [riskySurplus.raw])
 
-        expect(await this.contracts.risky.balanceOf(this.signers[0].address)).to.equal(previousRiskyBalance.add(premium.raw))
+        expect(await this.contracts.risky.balanceOf(this.signers[0].address)).to.equal(
+          previousRiskyBalance.add(riskySurplus.raw)
+        )
       })
 
-      it('transfers the stable from the caller to the engine', async function () {
+      it('transfers the stable deficit from the caller to the engine', async function () {
         const signerPreviousStableBalance = await this.contracts.stable.balanceOf(this.signers[0].address)
         const enginePreviousStableBalance = await this.contracts.stable.balanceOf(this.contracts.engine.address)
 
         const oldReserve = await this.contracts.engine.reserves(poolId)
-        const delStable = one.mul(oldReserve.reserveStable).div(oldReserve.liquidity)
+        // div delLiquidity by 2 because we are only liquidating 1 riskyCollateral = 1 unit of debt
+        const delStable = delLiquidity.div(2).mul(oldReserve.reserveStable).div(oldReserve.liquidity)
+        const stableDeficit = delStable
 
         await expect(() =>
-          this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
-        ).to.changeTokenBalances(this.contracts.stable, [this.contracts.engine], [delStable.raw])
+          this.contracts.engineRepay.repay(
+            poolId,
+            this.contracts.engineRepay.address,
+            riskyCollateral.raw,
+            '0',
+            false,
+            HashZero
+          )
+        ).to.changeTokenBalances(this.contracts.stable, [this.contracts.engine], [stableDeficit.raw])
 
         expect(await this.contracts.stable.balanceOf(this.signers[0].address)).to.equal(
-          signerPreviousStableBalance.sub(delStable.raw)
+          signerPreviousStableBalance.sub(stableDeficit.raw)
         )
 
         expect(await this.contracts.stable.balanceOf(this.contracts.engine.address)).to.equal(
-          enginePreviousStableBalance.add(delStable.raw)
+          enginePreviousStableBalance.add(stableDeficit.raw)
         )
       })
     })
@@ -198,7 +287,8 @@ describe('repay', function () {
           HashZero
         )
         expiredPoolId = computePoolId(this.contracts.engine.address, fig.maturity.raw, fig.sigma.raw, fig.strike.raw)
-        await this.contracts.engine.advanceTime(Time.YearInSeconds + 1)
+        const gracePeriod = 60 * 60 * 24
+        await this.contracts.engine.advanceTime(Time.YearInSeconds + 1 + gracePeriod)
         // give liquidity to engineSupply contract
         await this.contracts.engineAllocate.allocateFromExternal(
           expiredPoolId,
@@ -212,41 +302,60 @@ describe('repay', function () {
         await this.contracts.engineBorrow.borrow(
           expiredPoolId,
           this.contracts.engineBorrow.address,
-          parseWei('1').raw,
+          riskyCollateral.raw,
+          stableCollateral.raw,
           HashZero
         )
       })
 
-      it('repay engineBorrow borrow position, called by engineRepay: reduces stable in margin for engineRepay', async function () {
-        await this.contracts.engineDeposit.deposit(this.contracts.engineRepay.address, 0, parseWei('400').raw, HashZero)
-
+      it('repay engineBorrow`s riskyCollateral position, receive riskySurplus and pay stable deficit', async function () {
         const oldReserve = await this.contracts.engine.reserves(expiredPoolId)
-        const delStable = one.mul(oldReserve.reserveStable).div(oldReserve.liquidity)
+        const delRisky = delLiquidity.mul(oldReserve.reserveRisky).div(oldReserve.liquidity)
+        const delStable = delLiquidity.mul(oldReserve.reserveStable).div(oldReserve.liquidity)
 
+        let riskyDeficit = parseWei(0)
+        let riskySurplus = parseWei(0)
+        let stableDeficit = parseWei(0)
+        let stableSurplus = parseWei(0)
+
+        if (riskyCollateral.gt(delRisky)) riskySurplus = riskyCollateral.sub(delRisky)
+        else riskyDeficit = delRisky.sub(riskyCollateral)
+        if (riskyCollateral.gt(delRisky)) stableSurplus = stableCollateral.sub(delStable)
+        else stableDeficit = delStable.sub(stableCollateral)
+
+        await this.contracts.engineDeposit.deposit(this.contracts.engineRepay.address, 0, stableDeficit.raw, HashZero)
         await expect(
-          this.contracts.engineRepay.repay(expiredPoolId, this.contracts.engineBorrow.address, one.raw, true, HashZero)
-        ).to.decreaseMargin(this.contracts.engine, this.contracts.engineRepay.address, toBN(0), delStable.raw)
-      })
-
-      it('repay engineBorrow borrow position, called by engineRepay: increases risky in margin for engineBorrow', async function () {
-        await this.contracts.engineDeposit.deposit(this.contracts.engineRepay.address, 0, parseWei('400').raw, HashZero)
-
-        const oldReserve = await this.contracts.engine.reserves(expiredPoolId)
-        const delRisky = one.mul(oldReserve.reserveRisky).div(oldReserve.liquidity)
-        const premium = one.sub(delRisky)
-
-        await expect(
-          this.contracts.engineRepay.repay(expiredPoolId, this.contracts.engineBorrow.address, one.raw, true, HashZero)
-        ).to.increaseMargin(this.contracts.engine, this.contracts.engineBorrow.address, premium.raw, toBN(0))
+          this.contracts.engineRepay.repay(
+            expiredPoolId,
+            this.contracts.engineBorrow.address,
+            riskyCollateral.raw,
+            stableCollateral.raw,
+            true,
+            HashZero
+          )
+        ).to.decreaseMargin(
+          this.contracts.engine,
+          this.contracts.engineRepay.address,
+          riskySurplus.mul(-1).add(riskyDeficit).raw,
+          stableSurplus.mul(-1).add(stableDeficit).raw
+        )
       })
     })
   })
 
   describe('fail cases', function () {
     it('reverts if no debt', async function () {
-      await this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)
-      await expect(this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, false, HashZero)).to
-        .be.reverted
+      await this.contracts.engineRepay.repay(
+        poolId,
+        this.contracts.engineRepay.address,
+        riskyCollateral.raw,
+        stableCollateral.raw,
+        false,
+        HashZero
+      )
+      await expect(
+        this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, '0', false, HashZero)
+      ).to.be.reverted
     })
 
     it('reverts if repaying another account before maturity', async function () {
@@ -257,16 +366,17 @@ describe('repay', function () {
         HashZero
       )
       await this.contracts.engine.supply(poolId, parseWei('100').mul(8).div(10).raw)
-      await this.contracts.engineRepay.borrow(poolId, this.contracts.engineRepay.address, one.raw, HashZero)
+      await this.contracts.engineRepay.borrow(poolId, this.contracts.engineRepay.address, one.raw, '0', HashZero)
       await this.contracts.engineDeposit.deposit(this.signers[0].address, parseWei('100').raw, parseWei('100').raw, HashZero)
-      await expect(this.contracts.engine.repay(poolId, this.contracts.engineRepay.address, one.raw, true, HashZero)).to.be
-        .reverted
+      await expect(this.contracts.engine.repay(poolId, this.contracts.engineRepay.address, one.raw, '0', true, HashZero)).to
+        .be.reverted
     })
 
     describe('when from margin', function () {
       it('reverts if the stable balance of the margin is not sufficient', async function () {
-        await expect(this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, true, HashZero))
-          .to.be.reverted
+        await expect(
+          this.contracts.engineRepay.repay(poolId, this.contracts.engineRepay.address, one.raw, '0', true, HashZero)
+        ).to.be.reverted
       })
     })
 
@@ -277,6 +387,7 @@ describe('repay', function () {
             poolId,
             this.contracts.engineRepay.address,
             one.raw,
+            '0',
             false,
             HashZero
           )

--- a/test/unit/primitiveEngine/view/positions.ts
+++ b/test/unit/primitiveEngine/view/positions.ts
@@ -11,6 +11,6 @@ describe('position', function () {
   it('returns 0 for all fields when the position is uninitialized', async function () {
     expect(
       await this.contracts.engine.positions('0x6de0b49963079e3aead2278c2be4a58cc6afe973061c653ee98b527d1161a3c5')
-    ).to.deep.equal([BigNumber.from(0), BigNumber.from(0), BigNumber.from(0)])
+    ).to.deep.equal([BigNumber.from(0), BigNumber.from(0), BigNumber.from(0), BigNumber.from(0)])
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -82,8 +82,18 @@ declare global {
       decreasePositionFloat(engine: ContractTypes.PrimitiveEngine, posId: string, float: BigNumber): AsyncAssertion
       increasePositionLiquidity(engine: ContractTypes.PrimitiveEngine, posId: string, liquidity: BigNumber): AsyncAssertion
       decreasePositionLiquidity(engine: ContractTypes.PrimitiveEngine, posId: string, liquidity: BigNumber): AsyncAssertion
-      increasePositionDebt(engine: ContractTypes.PrimitiveEngine, posId: string, debt: BigNumber): AsyncAssertion
-      decreasePositionDebt(engine: ContractTypes.PrimitiveEngine, posId: string, debt: BigNumber): AsyncAssertion
+      increasePositionDebt(
+        engine: ContractTypes.PrimitiveEngine,
+        posId: string,
+        riskyCollateral: BigNumber,
+        stableCollateral: BigNumber
+      ): AsyncAssertion
+      decreasePositionDebt(
+        engine: ContractTypes.PrimitiveEngine,
+        posId: string,
+        riskyCollateral: BigNumber,
+        stableCollateral: BigNumber
+      ): AsyncAssertion
       increaseReserveRisky(engine: ContractTypes.PrimitiveEngine, poolId: string, amount: BigNumber): AsyncAssertion
       decreaseReserveRisky(engine: ContractTypes.PrimitiveEngine, poolId: string, amount: BigNumber): AsyncAssertion
       increaseReserveStable(engine: ContractTypes.PrimitiveEngine, poolId: string, amount: BigNumber): AsyncAssertion


### PR DESCRIPTION
# Overview of changes:
- Add a function to allow `lastTimestamp` of a pool to be updated. Previously, this could only be done through calling `swap()`.
- Change borrow and repay to be more explicit/clear with what is happening to collateral.
- Add a 24hr grace period after a pool is expired. After the grace period is finished, anyone can call `repay()` and take any profits from it.

# Detailed reasoning/changes:

## updateLastTimestamp
Changelog:
- Add internal `_updateLastTimestamp()`
- Add external `updateLastTimestamp()` that calls the internal `_updateLastTimestamp()`
- Change first few lines in swap to call `_updateLastTimestamp()`, which is where the logic is that was previously only in swap.

Reason behind the change is to allow the pool's lastTimestamp, effectively time until expiry "tau", to be updated outside of the swap.

The optimal condition for tau updates is on at most an 8hr interval, so exposing the function to do these updates make it easier to match the optimal case.

## Borrow and Repay Changes

- Detailed explanation of Borrow function: https://github.com/primitivefinance/primitive-v2-docs/blob/master/core-engine/what-is-the-engine/primitivev2engine/borrow.md
- Detailed explanation of Repay function: https://github.com/primitivefinance/primitive-v2-docs/blob/master/core-engine/what-is-the-engine/primitivev2engine/repay.md

Reasoning:

In the previous version, there was no explicit mention of collateral, but it was an assumption that could be understood after really thinking about the borrow/repay fns. The changes were made to be more clear about:
- What collateral gets stored in the contract
- What debt is created, and how that collateral backs it
- How debt is repaid and collateral is released

It also extends slightly from the previous version, which only allowed collateral to be denominated in the risky. However, the collateral could also be denominated in the stable, as long as there is `K` units of stable collateral per `1` unit of liquidity debt.

## Grace period
There is a 24hr grace period after the block.timestamp has eclipsed a pool's `maturity`, used in the `repay()` function. This gives some extra time to anyone with a borrow position to call `repay()`, which would send them any `surplus` profits from repaying the liquidity debt out of their collateral.

After this grace period is eclipsed, any `recipient` can be specified by the caller. The caller will then use the position's collateral to pay down the debt, and receive any `surplus` profits.