### PR TITLE
feat(check-expiry): prevents borrow and allocate in expired pools

### DIFF
--- a/contracts/PrimitiveEngine.sol
+++ b/contracts/PrimitiveEngine.sol
@@ -205,6 +205,7 @@ contract PrimitiveEngine is IPrimitiveEngine {
         Reserve.Data storage reserve = reserves[poolId];
 
         if (reserve.blockTimestamp == 0) revert UninitializedError();
+        if (_blockTimestamp() > calibrations[poolId].maturity) revert PoolExpiredError();
         delRisky = (delLiquidity * reserve.reserveRisky) / reserve.liquidity; // amount of risky tokens to provide
         delStable = (delLiquidity * reserve.reserveStable) / reserve.liquidity; // amount of stable tokens to provide
         if (delRisky * delStable == 0) revert ZeroDeltasError();
@@ -374,6 +375,7 @@ contract PrimitiveEngine is IPrimitiveEngine {
     {
         // Source: Convex Payoff Approximation. https://stanford.edu/~guillean/papers/cfmm-lending.pdf. Section 5.
         if (riskyCollateral == 0 && stableCollateral == 0) revert ZeroLiquidityError();
+        if (_blockTimestamp() > calibrations[poolId].maturity) revert PoolExpiredError();
 
         positions.borrow(poolId, riskyCollateral, stableCollateral);
 

--- a/test/unit/primitiveEngine/effect/allocate.ts
+++ b/test/unit/primitiveEngine/effect/allocate.ts
@@ -1,7 +1,7 @@
 import expect from '../../../shared/expect'
 import { waffle } from 'hardhat'
 import { constants, Wallet } from 'ethers'
-import { parseWei } from 'web3-units'
+import { parseWei, Time } from 'web3-units'
 
 import loadContext, { DEFAULT_CONFIG as config } from '../../context'
 import { computePoolId, computePositionId } from '../../../shared/utils'
@@ -151,6 +151,13 @@ describe('allocate', function () {
       it('reverts if the deltas are 0', async function () {
         await expect(this.contracts.engineAllocate.allocateFromMargin(poolId, this.signers[0].address, '0', HashZero)).to
           .reverted
+      })
+
+      it('reverts if pool is expired', async function () {
+        await this.contracts.engine.advanceTime(Time.YearInSeconds + 1)
+        await expect(
+          this.contracts.engineAllocate.allocateFromMargin(poolId, this.signers[0].address, '0', HashZero)
+        ).to.revertedWith('PoolExpiredError()')
       })
     })
   })

--- a/test/unit/primitiveEngine/effect/repay.ts
+++ b/test/unit/primitiveEngine/effect/repay.ts
@@ -297,7 +297,6 @@ describe('repay', function () {
         )
         expiredPoolId = computePoolId(this.contracts.engine.address, fig.maturity.raw, fig.sigma.raw, fig.strike.raw)
         const gracePeriod = 60 * 60 * 24
-        await this.contracts.engine.advanceTime(Time.YearInSeconds + 1 + gracePeriod)
         // give liquidity to engineSupply contract
         await this.contracts.engineAllocate.allocateFromExternal(
           expiredPoolId,
@@ -315,6 +314,7 @@ describe('repay', function () {
           stableCollateral.raw,
           HashZero
         )
+        await this.contracts.engine.advanceTime(Time.YearInSeconds + 1 + gracePeriod)
       })
 
       it('repay engineBorrow`s riskyCollateral position, receive riskySurplus and pay stable deficit', async function () {


### PR DESCRIPTION
Adds a check in borrow and allocate functions to revert if the pool is expired.