### PR TITLE
fix(5.8): changes condition in bal calcs from && to ||

### DIFF
--- a/contracts/PrimitiveEngine.sol
+++ b/contracts/PrimitiveEngine.sol
@@ -80,7 +80,7 @@ contract PrimitiveEngine is IPrimitiveEngine {
         (bool success, bytes memory data) = risky.staticcall(
             abi.encodeWithSelector(IERC20.balanceOf.selector, address(this))
         );
-        if (!success && data.length < 32) revert BalanceError();
+        if (!success || data.length < 32) revert BalanceError();
         return abi.decode(data, (uint256));
     }
 
@@ -89,7 +89,7 @@ contract PrimitiveEngine is IPrimitiveEngine {
         (bool success, bytes memory data) = stable.staticcall(
             abi.encodeWithSelector(IERC20.balanceOf.selector, address(this))
         );
-        if (!success && data.length < 32) revert BalanceError();
+        if (!success || data.length < 32) revert BalanceError();
         return abi.decode(data, (uint256));
     }
 


### PR DESCRIPTION
## Changes: Condition in `balanceRisky()` and `balanceStable()`
### Addresses: 5.8
- The functions improperly were using an `&&` operator rather than a `||` operator. To pass, the conditions must both be true.