### PR TITLE
fix(5.4): adds utilization check in Reserve.remove()

### DIFF
--- a/contracts/libraries/Reserve.sol
+++ b/contracts/libraries/Reserve.sol
@@ -101,6 +101,7 @@ library Reserve {
         reserve.reserveRisky -= delRisky.toUint128();
         reserve.reserveStable -= delStable.toUint128();
         reserve.liquidity -= delLiquidity.toUint128();
+        if ((reserve.float * 1000) / reserve.liquidity > 800) revert LiquidityError();
         update(reserve, blockTimestamp);
     }
 


### PR DESCRIPTION
## Ref: 5.4
- Adds a check in the `Reserve.sol` libraries `remove()` function that will revert if `reserve.float` / `reserve.liquidity` is greater than 80%, after liquidity is removed.