### PR TITLE
fix(L-03): changes return type uint128 -> uint64 on toUint64 fn

### DIFF
--- a/contracts/PrimitiveEngine.sol
+++ b/contracts/PrimitiveEngine.sol
@@ -152,7 +152,7 @@ contract PrimitiveEngine is IPrimitiveEngine {
         uint32 timestamp = _blockTimestamp();
         Calibration memory cal = Calibration({
             strike: strike.toUint128(),
-            sigma: sigma,
+            sigma: sigma.toUint64(),
             maturity: maturity,
             lastTimestamp: timestamp
         });

--- a/contracts/libraries/SafeCast.sol
+++ b/contracts/libraries/SafeCast.sol
@@ -10,7 +10,7 @@ library SafeCast {
     }
 
     /// @notice reverts if x > type(uint64).max
-    function toUint64(uint256 x) internal pure returns (uint128 z) {
+    function toUint64(uint256 x) internal pure returns (uint64 z) {
         require((z = uint64(x)) == x);
     }
 }


### PR DESCRIPTION
## Changes
- Updates return type on SafeCast.toUint64() from uint128 -> uint64
- Uses toUint64() fn in the Engine's `create()` function when initializing the `Calibration`, this was missing!