### PR TITLE
test(repay): fix repay tests to supply at lower than collateralization

### DIFF
--- a/contracts/libraries/Reserve.sol
+++ b/contracts/libraries/Reserve.sol
@@ -134,6 +134,7 @@ library Reserve {
     function repayFloat(Data storage reserve, uint256 delLiquidity) internal {
         reserve.float += delLiquidity.toUint128();
         reserve.debt -= delLiquidity.toUint128();
+        checkUtilization(reserve);
     }
 
     /// @notice                 Increases the extra fees from positive invariants and borrows

--- a/test/unit/primitiveEngine/effect/repay.ts
+++ b/test/unit/primitiveEngine/effect/repay.ts
@@ -18,7 +18,7 @@ export async function beforeEachRepay(signers: Wallet[], contracts: Contracts): 
   const poolId = computePoolId(contracts.engine.address, maturity.raw, sigma.raw, strike.raw)
   const initLiquidity = parseWei('100')
   await contracts.engineAllocate.allocateFromExternal(poolId, contracts.engineSupply.address, initLiquidity.raw, HashZero)
-  await contracts.engineSupply.supply(poolId, initLiquidity.mul(8).div(10).raw)
+  await contracts.engineSupply.supply(poolId, initLiquidity.mul(5).div(10).raw)
   await contracts.engineRepay.borrow(poolId, contracts.engineRepay.address, parseWei('1').raw, strike.raw, HashZero)
 }
 
@@ -297,7 +297,7 @@ describe('repay', function () {
           HashZero
         )
         // have the engineSupply contract supply the lp shares
-        await this.contracts.engineSupply.supply(expiredPoolId, parseWei('100').mul(8).div(10).raw)
+        await this.contracts.engineSupply.supply(expiredPoolId, parseWei('100').mul(5).div(10).raw)
         // have the engineBorrow borrow the lp shares
         await this.contracts.engineBorrow.borrow(
           expiredPoolId,


### PR DESCRIPTION
## Changes
- Adds `reserve.checkUtilization()` check in the `reserve.repayFloat` fn
- Updates tests to supply liquidity at slightly less than the max utilization