### PR TITLE
TOB-PTV-6: fix(tob-ptv-6): remove unused int128.percentage() fn

### DIFF
--- a/contracts/LibraryMathEchidna.sol
+++ b/contracts/LibraryMathEchidna.sol
@@ -5,55 +5,47 @@ import "./libraries/ReplicationMath.sol";
 import "./libraries/Units.sol";
 
 // npx hardhat clean && npx hardhat compile && echidna-test-2.0 . --contract LibraryMathEchidna --test-mode assertion
-contract LibraryMathEchidna { 
-	event AssertionFailed(string functionName, int128 v1, uint256 v2); 
-	using ReplicationMath for int128;
-	using Units for int128;
-	using Units for uint256;
+contract LibraryMathEchidna {
+    event AssertionFailed(string functionName, int128 v1, uint256 v2);
+    using ReplicationMath for int128;
+    using Units for int128;
+    using Units for uint256;
 
-	// Helper Functions for ReplicationMath.sol
-	function realisticSigma(uint256 sigma) internal pure returns(uint256) { 
-		// between 1 to 1e7 
-		return uint256(1 + sigma % (1e7 - 1));
-	}
-	function realisticGamma(uint256 sigma ) internal pure returns(uint256) { 
-		// between 9000 to Units.PERCENTAGE
-		return uint256(9000 + sigma % (Units.PERCENTAGE - 9000));
-	}
-	function realisticAmountIncluding0ne(uint256 amount) internal pure returns(uint256) { 
-		// between 1 - 100000 ether
-		return uint256(1 + amount% (100000 ether + 1));
-	}
+    // Helper Functions for ReplicationMath.sol
+    function realisticSigma(uint256 sigma) internal pure returns (uint256) {
+        // between 1 to 1e7
+        return uint256(1 + (sigma % (1e7 - 1)));
+    }
 
-	// --------------------- Units.sol -----------------------
-	function scaleUpAndScaleDownInverses(uint256 value, uint256 factor) public {
-		uint256 scaledFactor = (10e18+ factor % (10e18 + 1));
+    function realisticGamma(uint256 sigma) internal pure returns (uint256) {
+        // between 9000 to Units.PERCENTAGE
+        return uint256(9000 + (sigma % (Units.PERCENTAGE - 9000)));
+    }
 
-		uint256 scaledUpValue = value.scaleUp(scaledFactor);
-		uint256 scaledDownValue = scaledUpValue.scaleDown(scaledFactor);
-		
-		assert(scaledDownValue == value);
-	}
-	function scaleToAndFromX64Inverses(uint256 value, uint256 _decimals) public {
-		// will enforce factor between 0 - 12
-		uint256 factor = _decimals % (13); 
-		// will enforce scaledFactor between 1 - 10**12 , because 10**0 = 1
-		uint256 scaledFactor = 10**factor;
+    function realisticAmountIncluding0ne(uint256 amount) internal pure returns (uint256) {
+        // between 1 - 100000 ether
+        return uint256(1 + (amount % (100000 ether + 1)));
+    }
 
-		int128 scaledUpValue = value.scaleToX64(scaledFactor);
-		uint256 scaledDownValue = scaledUpValue.scalefromX64(scaledFactor);
-		
-		assert(scaledDownValue == value);
-	}
-	function scalePercentages(uint256 value) public {
-		require(value > Units.PERCENTAGE);
-		int128 signedPercentage =  value.percentage();
-		uint256 unsignedPercentage = signedPercentage.percentage();
-		
-		if(unsignedPercentage != value) {
-			emit AssertionFailed("scalePercentages", signedPercentage, unsignedPercentage);
-			assert(false);
-		}
-		
-	}
+    // --------------------- Units.sol -----------------------
+    function scaleUpAndScaleDownInverses(uint256 value, uint256 factor) public {
+        uint256 scaledFactor = (10e18 + (factor % (10e18 + 1)));
+
+        uint256 scaledUpValue = value.scaleUp(scaledFactor);
+        uint256 scaledDownValue = scaledUpValue.scaleDown(scaledFactor);
+
+        assert(scaledDownValue == value);
+    }
+
+    function scaleToAndFromX64Inverses(uint256 value, uint256 _decimals) public {
+        // will enforce factor between 0 - 12
+        uint256 factor = _decimals % (13);
+        // will enforce scaledFactor between 1 - 10**12 , because 10**0 = 1
+        uint256 scaledFactor = 10**factor;
+
+        int128 scaledUpValue = value.scaleToX64(scaledFactor);
+        uint256 scaledDownValue = scaledUpValue.scalefromX64(scaledFactor);
+
+        assert(scaledDownValue == value);
+    }
 }

--- a/contracts/libraries/Units.sol
+++ b/contracts/libraries/Units.sol
@@ -58,13 +58,6 @@ library Units {
         return denorm.divu(PERCENTAGE);
     }
 
-    /// @notice         Converts signed 64.64 fixed point percentage to a denormalized percetage integer
-    /// @param denorm   Signed 64.64 fixed point percentage
-    /// @return         Unsigned percentage denormalized with precision of 1e4
-    function percentage(int128 denorm) internal pure returns (uint256) {
-        return denorm.mulu(PERCENTAGE);
-    }
-
     /// @notice         Converts unsigned seconds integer into years as a signed 64.64 fixed point number
     /// @dev            Convert unsigned 256-bit integer number into signed 64.64 fixed point number
     /// @param s        Unsigned 256-bit integer amount of seconds to convert into year units


### PR DESCRIPTION
- Removes unused int128.percentage function in Units.sol
- Removes echidna test for percentage conversion back and forth (file also got reformatted by my local machines settings)